### PR TITLE
Добавил поддержку aspire, service discovery и open telemetry

### DIFF
--- a/aspire/Money.Aspire.AppHost/Money.Aspire.AppHost.csproj
+++ b/aspire/Money.Aspire.AppHost/Money.Aspire.AppHost.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>4bbf0756-e397-4214-94fb-7463f0b6079d</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.1.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\backend\Money.Api\Money.Api.csproj" />
+    <ProjectReference Include="..\..\frontend\Money.Web\Money.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/aspire/Money.Aspire.AppHost/Program.cs
+++ b/aspire/Money.Aspire.AppHost/Program.cs
@@ -1,0 +1,26 @@
+using Projects;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var apiProject = builder.AddProject<Money_Api>("api", launchProfileName: "aspire")
+    .WithExternalHttpEndpoints()
+    .WithEnvironment("AUTO_MIGRATE", "true")
+    .WithReplicas(1);
+
+if (Environment.GetEnvironmentVariable("ASPIRE_POSTGRES") == "true")
+{
+    var postgres = builder.AddPostgres("money")
+        .WithDataVolume(isReadOnly: false);
+    var postgresdb = postgres.AddDatabase("ApplicationDbContext");
+    apiProject.WithReference(postgresdb);
+}
+
+var webProject = builder.AddProject<Money_Web>("web", launchProfileName: "aspire")
+    .WithExternalHttpEndpoints()
+    .WithReference(apiProject);
+
+
+var webEndpoint = webProject.GetEndpoint("https");
+apiProject.WithEnvironment("CORS_ORIGIN", webEndpoint);
+
+builder.Build().Run();

--- a/aspire/Money.Aspire.AppHost/Properties/launchSettings.json
+++ b/aspire/Money.Aspire.AppHost/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17020;http://localhost:15141",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21263",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22276",
+        "ASPIRE_POSTGRES": "true"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15141",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19042",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20194",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    }
+  }
+}

--- a/aspire/Money.Aspire.AppHost/appsettings.Development.json
+++ b/aspire/Money.Aspire.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspire/Money.Aspire.AppHost/appsettings.json
+++ b/aspire/Money.Aspire.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/aspire/Money.Aspire.sln
+++ b/aspire/Money.Aspire.sln
@@ -1,0 +1,92 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35208.52
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Aspire.AppHost", "Money.Aspire.AppHost\Money.Aspire.AppHost.csproj", "{30243B3E-DBF0-41DF-B925-3B410EF628B7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "backend", "backend", "{FD4B84D1-AFC5-4F55-8832-64883493A327}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Api", "..\backend\Money.Api\Money.Api.csproj", "{987601E9-6F6D-4E28-AE3E-98A778E13340}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.ApiClient", "..\backend\Money.ApiClient\Money.ApiClient.csproj", "{91A42589-C744-416B-819C-A7B6F386C02F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Business", "..\backend\Money.Business\Money.Business.csproj", "{1E852510-1C09-4433-8368-A8786D0DBF45}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Common", "..\backend\Money.Common\Money.Common.csproj", "{6879F54B-2C2F-4ABB-9CC8-D796A7E1122D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Data", "..\backend\Money.Data\Money.Data.csproj", "{75522595-A18A-4CB0-8DA7-156B87757977}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "frontend", "frontend", "{100AA6E7-8C1F-4EBF-833D-50B3BD007613}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Web", "..\frontend\Money.Web\Money.Web.csproj", "{3E15DECC-CD05-48BC-ADEC-25C17E437AE7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{AFB3481F-13DA-46CE-ABD6-4CB1A7697FF6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.CoreLib", "..\libs\Money.CoreLib\Money.CoreLib.csproj", "{9658CB7E-8D15-4596-A4D9-A4109C463C67}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.WebAssembly.CoreLib", "..\libs\Money.WebAssembly.CoreLib\Money.WebAssembly.CoreLib.csproj", "{55CB1FA4-0985-4458-8D9B-6FA303BFB606}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Api.Tests", "..\backend\Money.Api.Tests\Money.Api.Tests.csproj", "{0370C976-1E5B-4DE4-A65D-31B42169F69A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{30243B3E-DBF0-41DF-B925-3B410EF628B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30243B3E-DBF0-41DF-B925-3B410EF628B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30243B3E-DBF0-41DF-B925-3B410EF628B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30243B3E-DBF0-41DF-B925-3B410EF628B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{987601E9-6F6D-4E28-AE3E-98A778E13340}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{987601E9-6F6D-4E28-AE3E-98A778E13340}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{987601E9-6F6D-4E28-AE3E-98A778E13340}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{987601E9-6F6D-4E28-AE3E-98A778E13340}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91A42589-C744-416B-819C-A7B6F386C02F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91A42589-C744-416B-819C-A7B6F386C02F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91A42589-C744-416B-819C-A7B6F386C02F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91A42589-C744-416B-819C-A7B6F386C02F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E852510-1C09-4433-8368-A8786D0DBF45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E852510-1C09-4433-8368-A8786D0DBF45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E852510-1C09-4433-8368-A8786D0DBF45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E852510-1C09-4433-8368-A8786D0DBF45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6879F54B-2C2F-4ABB-9CC8-D796A7E1122D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6879F54B-2C2F-4ABB-9CC8-D796A7E1122D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6879F54B-2C2F-4ABB-9CC8-D796A7E1122D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6879F54B-2C2F-4ABB-9CC8-D796A7E1122D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75522595-A18A-4CB0-8DA7-156B87757977}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75522595-A18A-4CB0-8DA7-156B87757977}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75522595-A18A-4CB0-8DA7-156B87757977}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75522595-A18A-4CB0-8DA7-156B87757977}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E15DECC-CD05-48BC-ADEC-25C17E437AE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E15DECC-CD05-48BC-ADEC-25C17E437AE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E15DECC-CD05-48BC-ADEC-25C17E437AE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E15DECC-CD05-48BC-ADEC-25C17E437AE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9658CB7E-8D15-4596-A4D9-A4109C463C67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9658CB7E-8D15-4596-A4D9-A4109C463C67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9658CB7E-8D15-4596-A4D9-A4109C463C67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9658CB7E-8D15-4596-A4D9-A4109C463C67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55CB1FA4-0985-4458-8D9B-6FA303BFB606}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55CB1FA4-0985-4458-8D9B-6FA303BFB606}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55CB1FA4-0985-4458-8D9B-6FA303BFB606}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55CB1FA4-0985-4458-8D9B-6FA303BFB606}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0370C976-1E5B-4DE4-A65D-31B42169F69A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0370C976-1E5B-4DE4-A65D-31B42169F69A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0370C976-1E5B-4DE4-A65D-31B42169F69A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0370C976-1E5B-4DE4-A65D-31B42169F69A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{987601E9-6F6D-4E28-AE3E-98A778E13340} = {FD4B84D1-AFC5-4F55-8832-64883493A327}
+		{1E852510-1C09-4433-8368-A8786D0DBF45} = {FD4B84D1-AFC5-4F55-8832-64883493A327}
+		{6879F54B-2C2F-4ABB-9CC8-D796A7E1122D} = {FD4B84D1-AFC5-4F55-8832-64883493A327}
+		{75522595-A18A-4CB0-8DA7-156B87757977} = {FD4B84D1-AFC5-4F55-8832-64883493A327}
+		{3E15DECC-CD05-48BC-ADEC-25C17E437AE7} = {100AA6E7-8C1F-4EBF-833D-50B3BD007613}
+		{0370C976-1E5B-4DE4-A65D-31B42169F69A} = {AFB3481F-13DA-46CE-ABD6-4CB1A7697FF6}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {760EC233-46EC-4056-8F5D-EBF4C02653BB}
+	EndGlobalSection
+EndGlobal

--- a/backend/Money.Api/Definitions/AuthorizationDefinition.cs
+++ b/backend/Money.Api/Definitions/AuthorizationDefinition.cs
@@ -8,7 +8,7 @@ public class AuthorizationDefinition : AppDefinition
         {
             options.AddPolicy("AllowSpecificOrigin",
                 policyBuilder => policyBuilder
-                    .WithOrigins("https://localhost:7168")
+                    .WithOrigins(builder.Configuration["CORS_ORIGIN"] ?? "https://localhost:7168")
                     .AllowAnyMethod()
                     .AllowAnyHeader());
         });

--- a/backend/Money.Api/Definitions/DbContextDefinition.cs
+++ b/backend/Money.Api/Definitions/DbContextDefinition.cs
@@ -14,4 +14,12 @@ public class DbContextDefinition : AppDefinition
             options.UseOpenIddict();
         });
     }
+
+    public override void ConfigureApplication(WebApplication app)
+    {
+        if (app.Configuration["AUTO_MIGRATE"] == "true")
+        {
+            app.Services.InilializeDbContext();
+        }
+    }
 }

--- a/backend/Money.Api/Money.Api.csproj
+++ b/backend/Money.Api/Money.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -35,6 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\libs\Money.CoreLib\Money.CoreLib.csproj" />
         <ProjectReference Include="..\Money.Business\Money.Business.csproj" />
         <ProjectReference Include="..\Money.Common\Money.Common.csproj" />
         <ProjectReference Include="..\Money.Data\Money.Data.csproj" />

--- a/backend/Money.Api/Program.cs
+++ b/backend/Money.Api/Program.cs
@@ -1,6 +1,6 @@
+using Money.CoreLib;
 using NLog;
 using NLog.Web;
-
 Logger? logger = LogManager.Setup()
     .LoadConfigurationFromAppSettings()
     .GetCurrentClassLogger();
@@ -13,13 +13,13 @@ try
 
     builder.Logging.ClearProviders();
     builder.Host.UseNLog();
-
+    builder.AddServiceDefaults();
     builder.AddDefinitions(typeof(Program));
 
     WebApplication app = builder.Build();
 
     app.UseDefinitions();
-
+    app.MapDefaultEndpoints();
     AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
     app.Run();
 }

--- a/backend/Money.Api/Properties/launchSettings.json
+++ b/backend/Money.Api/Properties/launchSettings.json
@@ -26,6 +26,16 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "aspire": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7124;http://localhost:5249",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/backend/Money.ApiClient/Money.ApiClient.csproj
+++ b/backend/Money.ApiClient/Money.ApiClient.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     </ItemGroup>
 
 </Project>

--- a/backend/Money.ApiClient/MoneyClient.cs
+++ b/backend/Money.ApiClient/MoneyClient.cs
@@ -1,4 +1,6 @@
-﻿using System.Net.Http.Json;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Net.Http.Json;
 
 namespace Money.ApiClient;
 
@@ -10,6 +12,13 @@ public class MoneyClient
         Log = log;
         Category = new CategoryClient(this);
         Operation = new OperationClient(this);
+    }
+
+    [ActivatorUtilitiesConstructor]
+    public MoneyClient(HttpClient client, ILogger<MoneyClient> log) :
+        this(client, p => log.LogInformation(p))
+    {
+
     }
 
     public HttpClient HttpClient { get; }

--- a/backend/Money.Business/Money.Business.csproj
+++ b/backend/Money.Business/Money.Business.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>

--- a/backend/Money.Business/Properties/launchSettings.json
+++ b/backend/Money.Business/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Money.Business": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:52535;http://localhost:52536"
+    }
+  }
+}

--- a/backend/Money.Business/Services/FileService.cs
+++ b/backend/Money.Business/Services/FileService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Money.Business.Configs;
 using File = Money.Business.Models.File;
 

--- a/backend/Money.Data/ApplicationDbContextInilializer.cs
+++ b/backend/Money.Data/ApplicationDbContextInilializer.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Money.Data
+{
+    public static class ApplicationDbContextInilializer
+    {
+        public static IServiceProvider InilializeDbContext(this IServiceProvider serviceProvider)
+        {
+            using var scope = serviceProvider.CreateScope();
+            scope.ServiceProvider.GetRequiredService<ApplicationDbContext>()
+                .Database.Migrate();
+
+            return serviceProvider;
+        }
+    }
+}

--- a/backend/Money.sln
+++ b/backend/Money.sln
@@ -13,9 +13,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Api.Tests", "Money.Ap
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{C048BFE0-0921-416E-999C-2DDE4D278C93}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Money.ApiClient", "Money.ApiClient\Money.ApiClient.csproj", "{6412D321-7428-4A0F-946B-1C88E2ED524D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.ApiClient", "Money.ApiClient\Money.ApiClient.csproj", "{6412D321-7428-4A0F-946B-1C88E2ED524D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Money.Business", "Money.Business\Money.Business.csproj", "{337534D0-110A-48F0-8CF8-3A7E6DDCA9C3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Business", "Money.Business\Money.Business.csproj", "{337534D0-110A-48F0-8CF8-3A7E6DDCA9C3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.CoreLib", "..\libs\Money.CoreLib\Money.CoreLib.csproj", "{24F8ED76-3DDA-424F-84BD-AE1D2DC9EAB5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,6 +49,10 @@ Global
 		{337534D0-110A-48F0-8CF8-3A7E6DDCA9C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{337534D0-110A-48F0-8CF8-3A7E6DDCA9C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{337534D0-110A-48F0-8CF8-3A7E6DDCA9C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24F8ED76-3DDA-424F-84BD-AE1D2DC9EAB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24F8ED76-3DDA-424F-84BD-AE1D2DC9EAB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24F8ED76-3DDA-424F-84BD-AE1D2DC9EAB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24F8ED76-3DDA-424F-84BD-AE1D2DC9EAB5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/frontend/Money.Web.sln
+++ b/frontend/Money.Web.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.Web", "Money.Web\Mone
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.ApiClient", "..\backend\Money.ApiClient\Money.ApiClient.csproj", "{76708031-7C46-4D1D-A086-8F1AFC337311}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Money.WebAssembly.CoreLib", "..\libs\Money.WebAssembly.CoreLib\Money.WebAssembly.CoreLib.csproj", "{0AB45AF6-7602-485D-979C-1BB8CA8101F4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{76708031-7C46-4D1D-A086-8F1AFC337311}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76708031-7C46-4D1D-A086-8F1AFC337311}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76708031-7C46-4D1D-A086-8F1AFC337311}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AB45AF6-7602-485D-979C-1BB8CA8101F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AB45AF6-7602-485D-979C-1BB8CA8101F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AB45AF6-7602-485D-979C-1BB8CA8101F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AB45AF6-7602-485D-979C-1BB8CA8101F4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/frontend/Money.Web/Money.Web.csproj
+++ b/frontend/Money.Web/Money.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -30,6 +30,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\backend\Money.ApiClient\Money.ApiClient.csproj" />
+        <ProjectReference Include="..\..\libs\Money.WebAssembly.CoreLib\Money.WebAssembly.CoreLib.csproj" />
     </ItemGroup>
 
 </Project>

--- a/frontend/Money.Web/Program.cs
+++ b/frontend/Money.Web/Program.cs
@@ -6,7 +6,6 @@ using Money.WebAssembly.CoreLib;
 using MudBlazor.Services;
 using MudBlazor.Translations;
 using NCalc.DependencyInjection;
-using System.Collections;
 
 WebAssemblyHostBuilder builder = WebAssemblyHostBuilder.CreateDefault(args);
 Uri apiUri = new Uri("https+http://api/");
@@ -14,11 +13,6 @@ Uri apiUri = new Uri("https+http://api/");
 builder.AddServiceDefaults();
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
-
-foreach (DictionaryEntry d in Environment.GetEnvironmentVariables())
-{
-    Console.WriteLine($"{d.Key} {d.Value}");
-}
 
 builder.Services.AddMudServices(configuration =>
 {

--- a/frontend/Money.Web/Properties/launchSettings.json
+++ b/frontend/Money.Web/Properties/launchSettings.json
@@ -26,6 +26,16 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "aspire": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "https://localhost:7168;http://localhost:5028",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/frontend/Money.Web/Services/AuthenticationService.cs
+++ b/frontend/Money.Web/Services/AuthenticationService.cs
@@ -9,18 +9,16 @@ using AuthData = Money.Web.Models.AuthData;
 namespace Money.Web.Services;
 
 public class AuthenticationService(
-    IHttpClientFactory clientFactory,
+    HttpClient client,
     AuthenticationStateProvider authStateProvider,
     ILocalStorageService localStorage)
 {
     public const string AccessTokenKey = "authToken";
     public const string RefreshTokenKey = "refreshToken";
 
-    private readonly HttpClient _client = clientFactory.CreateClient("api_base");
-
     public async Task<Result> RegisterAsync(UserDto user)
     {
-        HttpResponseMessage response = await _client.PostAsJsonAsync("Account/register", new { user.Email, user.Password });
+        HttpResponseMessage response = await client.PostAsJsonAsync("Account/register", new { user.Email, user.Password });
 
         if (response.IsSuccessStatusCode == false)
         {
@@ -67,15 +65,15 @@ public class AuthenticationService(
             new KeyValuePair<string, string>("refresh_token", refreshToken),
         ]);
 
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         Result<AuthData> result = await AuthenticateAsync(requestContent);
         return result.Map(data => data.AccessToken);
     }
 
     private async Task<Result<AuthData>> AuthenticateAsync(FormUrlEncodedContent requestContent)
     {
-        HttpResponseMessage response = await _client.PostAsync("connect/token", requestContent);
-        _client.DefaultRequestHeaders.Clear();
+        HttpResponseMessage response = await client.PostAsync("connect/token", requestContent);
+        client.DefaultRequestHeaders.Clear();
 
         if (response.IsSuccessStatusCode == false)
         {

--- a/frontend/Money.Web/Services/JwtParser.cs
+++ b/frontend/Money.Web/Services/JwtParser.cs
@@ -4,10 +4,8 @@ using System.Security.Claims;
 
 namespace Money.Web.Services;
 
-public class JwtParser(IHttpClientFactory clientFactory)
+public class JwtParser(HttpClient client)
 {
-    private readonly HttpClient _client = clientFactory.CreateClient("api_base");
-
     public async Task<ClaimsPrincipal?> ValidateJwt(string token)
     {
         Dictionary<string, object>? claimsDictionary = await GetUserInfo(token);
@@ -37,12 +35,13 @@ public class JwtParser(IHttpClientFactory clientFactory)
         return new ClaimsPrincipal(claimsIdentity);
     }
 
+    // TODO это точно ответственность JWT парсера?
     private async Task<Dictionary<string, object>?> GetUserInfo(string accessToken)
     {
         HttpRequestMessage request = new(HttpMethod.Get, "connect/userinfo");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-        HttpResponseMessage response = await _client.SendAsync(request);
+        HttpResponseMessage response = await client.SendAsync(request);
 
         if (response.IsSuccessStatusCode == false)
         {

--- a/frontend/Money.Web/wwwroot/appsettings.Development.json
+++ b/frontend/Money.Web/wwwroot/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Services": {
+    "api": {
+      "https": [
+        "localhost:7124"
+      ]
+    }
+  }
+}

--- a/frontend/Money.Web/wwwroot/appsettings.json
+++ b/frontend/Money.Web/wwwroot/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Services": {
+    "api": {
+      "https": [
+        "localhost:7124"
+      ]
+    }
+  }
+}

--- a/libs/Money.CoreLib/HostApplicationBuilderExtensions.cs
+++ b/libs/Money.CoreLib/HostApplicationBuilderExtensions.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Money.CoreLib
+{
+    public static class HostApplicationBuilderExtensions
+    {
+        public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+        {
+            builder.ConfigureOpenTelemetry();
+
+            builder.AddDefaultHealthChecks();
+
+            builder.Services.AddServiceDiscovery();
+
+            builder.Services.ConfigureHttpClientDefaults(http =>
+            {
+                http.AddStandardResilienceHandler();
+                http.AddServiceDiscovery();
+            });
+
+            return builder;
+        }
+
+
+        public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+        {
+            builder.Logging.AddOpenTelemetryDefaults();
+
+            builder.Services.AddOpenTelemetry()
+                .WithMetrics(metrics =>
+                {
+                    metrics.AddAspNetCoreInstrumentation()
+                        .AddHttpClientInstrumentation()
+                        .AddRuntimeInstrumentation();
+                })
+                .WithTracing(tracing =>
+                {
+                    tracing.AddAspNetCoreInstrumentation()
+                        .AddHttpClientInstrumentation();
+                });
+
+            builder.AddOpenTelemetryExporters();
+
+            return builder;
+        }
+
+        public static ILoggingBuilder AddOpenTelemetryDefaults(this ILoggingBuilder logging)
+        {
+            logging.AddOpenTelemetry(logging =>
+            {
+                logging.IncludeFormattedMessage = true;
+                logging.IncludeScopes = true;
+            });
+
+            return logging;
+        }
+
+
+        private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
+        {
+            var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+            if (useOtlpExporter)
+            {
+                builder.Services.AddOpenTelemetry().UseOtlpExporter();
+            }
+
+            return builder;
+        }
+
+
+        public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+        {
+            builder.Services.AddHealthChecks()
+                .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+            return builder;
+        }
+
+        public static WebApplication MapDefaultEndpoints(this WebApplication app)
+        {
+            if (app.Environment.IsDevelopment())
+            {
+                app.MapHealthChecks("/health");
+
+                app.MapHealthChecks("/alive", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains("live")
+                });
+            }
+
+            return app;
+        }
+
+    }
+}

--- a/libs/Money.CoreLib/HostApplicationBuilderExtensions.cs
+++ b/libs/Money.CoreLib/HostApplicationBuilderExtensions.cs
@@ -44,6 +44,16 @@ namespace Money.CoreLib
                 .WithTracing(tracing =>
                 {
                     tracing.AddAspNetCoreInstrumentation()
+                        .AddEntityFrameworkCoreInstrumentation(p =>
+                        {
+                            p.SetDbStatementForText = true;
+                            p.EnrichWithIDbCommand = (activity, command) =>
+                            {
+                                var stateDisplayName = $"{command.CommandType} main";
+                                activity.DisplayName = stateDisplayName;
+                                activity.SetTag("db.name", stateDisplayName);
+                            };
+                        })
                         .AddHttpClientInstrumentation();
                 });
 

--- a/libs/Money.CoreLib/Money.CoreLib.csproj
+++ b/libs/Money.CoreLib/Money.CoreLib.csproj
@@ -12,6 +12,7 @@
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
 	</ItemGroup>

--- a/libs/Money.CoreLib/Money.CoreLib.csproj
+++ b/libs/Money.CoreLib/Money.CoreLib.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
+		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.1.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+	</ItemGroup>
+</Project>

--- a/libs/Money.WebAssembly.CoreLib/Money.WebAssembly.CoreLib.csproj
+++ b/libs/Money.WebAssembly.CoreLib/Money.WebAssembly.CoreLib.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.2" />
+	  <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
+	  <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.1.0" />
+	  <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+	  <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+	  <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+	  <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+  </ItemGroup>
+
+</Project>

--- a/libs/Money.WebAssembly.CoreLib/Properties/launchSettings.json
+++ b/libs/Money.WebAssembly.CoreLib/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Money.WebAssembly.CoreLib": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:60354;http://localhost:60355"
+    }
+  }
+}

--- a/libs/Money.WebAssembly.CoreLib/WebAssemblyHostBuilderExtensions.cs
+++ b/libs/Money.WebAssembly.CoreLib/WebAssemblyHostBuilderExtensions.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Money.WebAssembly.CoreLib
+{
+    public static class WebAssemblyHostBuilderExtensions
+    {
+        public static WebAssemblyHostBuilder AddServiceDefaults(this WebAssemblyHostBuilder builder)
+        {
+            builder.ConfigureOpenTelemetry();
+            builder.Services.AddServiceDiscovery();
+
+            builder.Services.ConfigureHttpClientDefaults(http =>
+            {
+                http.AddStandardResilienceHandler();
+                http.AddServiceDiscovery();
+
+            });
+            builder.Services.Configure<ConfigurationServiceEndpointProviderOptions>(
+                static options =>
+                {
+                    options.SectionName = "Services";
+                    options.ShouldApplyHostNameMetadata = static endpoint =>
+                    {
+                        return true;
+                    };
+                });
+            return builder;
+        }
+
+
+        public static WebAssemblyHostBuilder ConfigureOpenTelemetry(this WebAssemblyHostBuilder builder)
+        {
+            builder.Services.AddOpenTelemetry()
+                .WithMetrics(metrics =>
+                {
+                    metrics.AddHttpClientInstrumentation();
+                })
+                .WithTracing(tracing =>
+                {
+                    tracing.AddHttpClientInstrumentation();
+                });
+
+            return builder;
+        }
+
+
+    }
+}


### PR DESCRIPTION
**Косметические улучшения.**
- Добавлена поддержка Aspire, запускающий web, api и pgsql (Пожалуйста, используйте только в целях разработки)
- Добавлены базовые библиотеки для asp.net core и blazor wasm, включающие поддержку ServiceDiscovery и OpenTelemetry
- Убрано прямое использование IHttpClientFactory в пользу явной инъекции нужного http клиента
- Добавлен конструктор для MoneyClient, явно принимающий ILogger. Реализация логирования через Action<string> Log не внушает доверия
- Добавлена возможность включения автоматического накатывания миграций на бд. Включается через конфигурацию AUTO_MIGRATE. Ожидаемое значения для включения - true. Используется проектом Aspire.AppHost
- Добавлено новое решение Money.Aspire включающее все проекты. 
