### PR TITLE
Мелкие исправления

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,13 @@ jobs:
     if: ${{ github.event.inputs.tag != 'production' }}
     uses: ./.github/workflows/frontend.yml
 
+  publish-smoke:
+    if: ${{ github.event.inputs.tag != 'production' }}
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/publish-smoke.yml
+
   build-and-deploy:
     runs-on:
       labels: BobGroupWindowsServer
@@ -61,15 +68,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup .NET Core SDK ${{ env.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-      
+
       - name: API Restore dependencies
         run: dotnet restore ${{ env.API_PROJECT_FILE }}
-      
+
       - name: API Publish
         run: dotnet publish ${{ env.API_PROJECT_FILE }} -c ${{ github.event.inputs.configuration }} -o ${{ env.API_PUBLISH_FOLDER }}
 
@@ -81,34 +88,33 @@ jobs:
           $SambaServer = "192.168.0.17"
           $SambaShare = "publish"
           $DestDir = "\\$SambaServer\$SambaShare\bob217money\production\api"
-      
+          
           # Подключаем SMB-шару с аутентификацией
           net use \\$SambaServer\$SambaShare /user:$env:SAMBA_USER $env:SAMBA_PASS /persistent:no
-      
+          
           # Создаем папку назначения (если её нет)
           if (-not (Test-Path -Path $DestDir)) {
             New-Item -ItemType Directory -Path $DestDir -Force | Out-Null
           }
-      
+          
           # Копируем всё содержимое (рекурсивно)
           Copy-Item -Path "${{ env.API_PUBLISH_FOLDER }}\*" -Destination $DestDir -Recurse -Force -Exclude "web.config", "appsettings.json", "nlog.config"
-      
+          
           # Отключаем шару
           net use \\$SambaServer\$SambaShare /delete /y
-      
+
       - name: Restore workload
         run: dotnet workload restore ${{ env.WEB_PROJECT_FILE }}
-      
+
       - name: WEB Restore dependencies
         run: dotnet restore ${{ env.WEB_PROJECT_FILE }}
-      
+
       - name: WEB Publish
         env:
           TMP: ${{ runner.temp }}
           TEMP: ${{ runner.temp }}
-        run: dotnet publish ${{ env.WEB_PROJECT_FILE }} -c ${{ github.event.inputs.configuration }} -o ${{ env.WEB_PUBLISH_FOLDER }}
-      
-      
+        run: dotnet publish ${{ env.WEB_PROJECT_FILE }} -c ${{ github.event.inputs.configuration }} -o ${{ env.WEB_PUBLISH_FOLDER }} ${{ github.event.inputs.configuration == 'debug' && '-p:RunAOTCompilation=false -p:BlazorEnableCompression=false' || '' }}
+
       - name: WEB Copy new files
         env:
           SAMBA_USER: ${{ vars.SAMBA_USER }}
@@ -117,17 +123,17 @@ jobs:
           $SambaServer = "192.168.0.17"
           $SambaShare = "publish"
           $DestDir = "\\$SambaServer\$SambaShare\bob217money\production\web"
-      
+          
           # Подключаем SMB-шару с аутентификацией
           net use \\$SambaServer\$SambaShare /user:$env:SAMBA_USER $env:SAMBA_PASS /persistent:no
-      
+          
           # Создаем папку назначения (если её нет)
           if (-not (Test-Path -Path $DestDir)) {
             New-Item -ItemType Directory -Path $DestDir -Force | Out-Null
           }
-      
+          
           # Копируем всё содержимое (рекурсивно)
           Copy-Item -Path "${{ env.WEB_PUBLISH_FOLDER }}\*" -Destination $DestDir -Recurse -Force -Exclude "web.config", "appsettings.json", "nlog.config"
-      
+          
           # Отключаем шару
           net use \\$SambaServer\$SambaShare /delete /y

--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -134,13 +134,17 @@ jobs:
           echo "index.html not served"; exit 1
 
       - name: Check Blazor framework
+        working-directory: ${{ env.WEB_PUBLISH_FOLDER }}/wwwroot
         run: |
-          script_path=$(curl -fsS http://127.0.0.1:8080/index.html | grep -oE '_framework/blazor\.webassembly[^"]*\.js' | head -n 1)
-          if [ -z "$script_path" ]; then
-            echo "blazor.webassembly script not found in index.html"; exit 1
+          echo "Files in _framework/ (top 20):"
+          ls _framework/ | head -n 20
+          script=$(ls _framework/blazor.webassembly*.js 2>/dev/null | head -n 1)
+          if [ -z "$script" ]; then
+            echo "blazor.webassembly*.js not found in _framework/"; exit 1
           fi
-          echo "Checking /$script_path"
-          curl -fsS -o /dev/null "http://127.0.0.1:8080/$script_path"
+          script_name=$(basename "$script")
+          echo "Checking /_framework/$script_name"
+          curl -fsS -o /dev/null "http://127.0.0.1:8080/_framework/$script_name"
 
       - name: Stop server
         if: always()

--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -1,0 +1,622 @@
+﻿name: Publish smoke
+
+on:
+  workflow_call:
+
+env:
+  API_PROJECT_FILE: backend/Money.Api/Money.Api.csproj
+  API_PUBLISH_FOLDER: publish/api
+  WEB_PROJECT_FILE: frontend/Money.Web/Money.Web.csproj
+  WEB_PUBLISH_FOLDER: publish/web
+
+jobs:
+  api-smoke:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: money
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore ${{ env.API_PROJECT_FILE }}
+
+      - name: Publish
+        run: dotnet publish ${{ env.API_PROJECT_FILE }} -c Release --no-restore -o ${{ env.API_PUBLISH_FOLDER }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-publish
+          path: ${{ env.API_PUBLISH_FOLDER }}
+          retention-days: 3
+
+      - name: Start API
+        working-directory: ${{ env.API_PUBLISH_FOLDER }}
+        env:
+          ASPNETCORE_ENVIRONMENT: Development
+          ASPNETCORE_URLS: http://127.0.0.1:5000
+          ConnectionStrings__ApplicationDbContext: Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=money;Pooling=true;
+          AUTO_MIGRATE: "true"
+        run: |
+          nohup dotnet Money.Api.dll > api.log 2>&1 &
+          echo $! > api.pid
+
+      - name: Wait for /alive
+        run: |
+          for i in $(seq 1 40); do
+            if curl -fsS http://127.0.0.1:5000/alive; then
+              echo "alive OK"; exit 0
+            fi
+            sleep 2
+          done
+          echo "API did not become alive in 80s"; exit 1
+
+      - name: Check /health
+        run: curl -fsS http://127.0.0.1:5000/health
+
+      - name: Check /swagger
+        run: curl -fsS -o /dev/null -w "swagger=%{http_code}\n" http://127.0.0.1:5000/swagger/index.html
+
+      - name: Stop API
+        if: always()
+        run: |
+          if [ -f ${{ env.API_PUBLISH_FOLDER }}/api.pid ]; then
+            kill "$(cat ${{ env.API_PUBLISH_FOLDER }}/api.pid)" || true
+          fi
+
+      - name: Upload API log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-smoke-log
+          path: ${{ env.API_PUBLISH_FOLDER }}/api.log
+          retention-days: 3
+          if-no-files-found: ignore
+
+  web-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore workload
+        run: dotnet workload restore ${{ env.WEB_PROJECT_FILE }}
+
+      - name: Restore
+        run: dotnet restore ${{ env.WEB_PROJECT_FILE }}
+
+      - name: Publish
+        run: dotnet publish ${{ env.WEB_PROJECT_FILE }} -c Release --no-restore -o ${{ env.WEB_PUBLISH_FOLDER }} -p:RunAOTCompilation=false -p:BlazorEnableCompression=false
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-publish
+          path: ${{ env.WEB_PUBLISH_FOLDER }}/wwwroot
+          retention-days: 3
+
+      - name: Serve wwwroot
+        working-directory: ${{ env.WEB_PUBLISH_FOLDER }}/wwwroot
+        run: |
+          nohup python3 -m http.server 8080 > web.log 2>&1 &
+          echo $! > web.pid
+
+      - name: Check index.html
+        run: |
+          for i in $(seq 1 20); do
+            if curl -fsS -o /dev/null http://127.0.0.1:8080/index.html; then
+              echo "index.html OK"; exit 0
+            fi
+            sleep 1
+          done
+          echo "index.html not served"; exit 1
+
+      - name: Check Blazor framework
+        run: curl -fsS -o /dev/null http://127.0.0.1:8080/_framework/blazor.webassembly.js
+
+      - name: Stop server
+        if: always()
+        run: |
+          if [ -f ${{ env.WEB_PUBLISH_FOLDER }}/wwwroot/web.pid ]; then
+            kill "$(cat ${{ env.WEB_PUBLISH_FOLDER }}/wwwroot/web.pid)" || true
+          fi
+
+  integration-smoke:
+    needs: [api-smoke, web-smoke]
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: money
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      API_URL: http://127.0.0.1:5000
+      WEB_URL: http://127.0.0.1:8080
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Download API artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: api-publish
+          path: api-publish
+
+      - name: Download Web artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-publish
+          path: web-publish
+
+      - name: Patch Web appsettings.json to point at API
+        run: |
+          cat > web-publish/appsettings.json <<EOF
+          {
+            "Services": {
+              "api": { "https": [ "${{ env.API_URL }}" ] }
+            }
+          }
+          EOF
+          cat web-publish/appsettings.json
+
+      - name: Start API
+        working-directory: api-publish
+        env:
+          ASPNETCORE_ENVIRONMENT: Development
+          ASPNETCORE_URLS: http://127.0.0.1:5000
+          ConnectionStrings__ApplicationDbContext: Host=localhost;Port=5432;Username=postgres;Password=postgres;Database=money;Pooling=true;
+          AUTO_MIGRATE: "true"
+          CORS_ORIGIN: http://127.0.0.1:8080
+        run: |
+          nohup dotnet Money.Api.dll > api.log 2>&1 &
+          echo $! > api.pid
+
+      - name: Wait for API /alive
+        run: |
+          for i in $(seq 1 40); do
+            curl -fsS ${{ env.API_URL }}/alive && exit 0
+            sleep 2
+          done
+          echo "API did not become alive"; exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install static server (SPA-capable)
+        run: npm install -g serve@14
+
+      - name: Serve Web (SPA fallback to index.html)
+        working-directory: web-publish
+        run: |
+          nohup serve -s . -l tcp://127.0.0.1:8080 --no-request-logging > web.log 2>&1 &
+          echo $! > web.pid
+
+      - name: Wait for Web
+        run: |
+          for i in $(seq 1 40); do
+            curl -fsS -o /dev/null ${{ env.WEB_URL }}/index.html && exit 0
+            sleep 1
+          done
+          echo "Web not serving"; cat web-publish/web.log || true; exit 1
+
+      - name: Web serves patched appsettings.json
+        run: |
+          body=$(curl -fsS ${{ env.WEB_URL }}/appsettings.json)
+          echo "$body"
+          echo "$body" | grep -q "127.0.0.1:5000" || { echo "appsettings not patched"; exit 1; }
+
+      - name: CORS preflight from Web origin
+        run: |
+          resp=$(curl -sS -D - -o /dev/null -X OPTIONS \
+            -H "Origin: ${{ env.WEB_URL }}" \
+            -H "Access-Control-Request-Method: GET" \
+            -H "Access-Control-Request-Headers: authorization,content-type" \
+            ${{ env.API_URL }}/connect/authorize)
+          echo "$resp"
+          echo "$resp" | tr -d '\r' | grep -iq "^access-control-allow-origin: ${{ env.WEB_URL }}$" \
+            || { echo "CORS Allow-Origin mismatch"; exit 1; }
+
+      - name: OIDC discovery from Web origin
+        run: |
+          body=$(curl -fsS -H "Origin: ${{ env.WEB_URL }}" ${{ env.API_URL }}/.well-known/openid-configuration)
+          echo "$body" | head -c 500
+          echo "$body" | grep -q "authorization_endpoint" \
+            || { echo "OIDC discovery response invalid"; exit 1; }
+
+      - name: Install Playwright
+        run: |
+          npm init -y >/dev/null
+          npm i -D @playwright/test >/dev/null
+          npx playwright install chromium --with-deps
+
+      - name: Write Playwright smoke script
+        run: |
+          mkdir -p smoke
+          cat > smoke/smoke.mjs <<'JS'
+          import { chromium } from '@playwright/test';
+
+          const WEB = process.env.WEB_URL;
+          const API = process.env.API_URL;
+
+          const IGNORED_404 = [
+            '/_framework/aspnetcore-browser-refresh.js',
+          ];
+
+          const failures = [];
+          const browser = await chromium.launch();
+          const context = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+          const page = await context.newPage();
+
+          const consoleErrors = [];
+          page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+          });
+
+          const apiResponses = [];
+          const badResponses = [];
+          page.on('response', (resp) => {
+            const url = resp.url();
+            const status = resp.status();
+            if (url.startsWith(API)) apiResponses.push({ url, status });
+            if (status >= 400 && !IGNORED_404.some((s) => url.endsWith(s))) {
+              badResponses.push({ url, status });
+            }
+          });
+
+          console.log('[phase 1] Anonymous landing');
+          await page.goto(WEB, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+          await page.waitForFunction(
+            () => !document.querySelector('#app .loading-bg'),
+            null,
+            { timeout: 90_000 },
+          );
+          await page.waitForSelector('.mud-layout, .mud-container, form', { timeout: 30_000 });
+          await page.waitForTimeout(2000);
+
+          const corsProbe = await page.evaluate(async (api) => {
+            try {
+              const r = await fetch(`${api}/.well-known/openid-configuration`, { mode: 'cors' });
+              return { ok: r.ok, status: r.status };
+            } catch (e) {
+              return { ok: false, error: String(e) };
+            }
+          }, API);
+          console.log('CORS probe:', JSON.stringify(corsProbe));
+
+          const errorUiVisible = await page.evaluate(() => {
+            const el = document.getElementById('blazor-error-ui');
+            return el && getComputedStyle(el).display !== 'none';
+          });
+          if (errorUiVisible) failures.push('Blazor error UI visible after anonymous load');
+          if (!corsProbe.ok) failures.push(`CORS probe failed: ${JSON.stringify(corsProbe)}`);
+
+          await page.screenshot({ path: 'smoke/anonymous.png', fullPage: true });
+
+          console.log('[phase 2] Auth flow');
+          const creds = { username: `smoke${Date.now()}`, password: 'SmokePass123!' };
+
+          const register = await page.evaluate(async ({ api, u, p }) => {
+            const r = await fetch(`${api}/accounts/register`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ UserName: u, Password: p }),
+            });
+            return { status: r.status, body: await r.text() };
+          }, { api: API, u: creds.username, p: creds.password });
+          console.log('Register:', register.status, register.body?.slice?.(0, 200) ?? '');
+          if (register.status !== 204) failures.push(`Register failed: ${JSON.stringify(register)}`);
+
+          const token = await page.evaluate(async ({ api, u, p }) => {
+            const r = await fetch(`${api}/connect/token`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/x-www-form-urlencoded' },
+              body: new URLSearchParams({ grant_type: 'password', username: u, password: p }).toString(),
+              credentials: 'include',
+            });
+            const text = await r.text();
+            let body;
+            try { body = JSON.parse(text); } catch { body = text; }
+            return { status: r.status, body };
+          }, { api: API, u: creds.username, p: creds.password });
+          console.log('Token status:', token.status);
+          if (token.status !== 200 || !token.body?.access_token) {
+            failures.push(`Token exchange failed: ${JSON.stringify(token).slice(0, 400)}`);
+          }
+
+          if (token.body?.access_token) {
+            // Blazored.LocalStorage serializes strings as JSON → must store JSON-encoded
+            await page.evaluate(({ a, r }) => {
+              localStorage.setItem('authToken', JSON.stringify(a));
+              localStorage.setItem('refreshToken', JSON.stringify(r));
+            }, { a: token.body.access_token, r: token.body.refresh_token ?? '' });
+
+            const authApiBefore = apiResponses.length;
+
+            await page.goto(`${WEB}/categories`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+            await page.waitForFunction(
+              () => !document.querySelector('#app .loading-bg'),
+              null,
+              { timeout: 90_000 },
+            );
+            await page.waitForSelector('.mud-tabs, .mud-container, .mud-progress-circular', { timeout: 30_000 });
+            await page.waitForTimeout(3000);
+
+            await page.screenshot({ path: 'smoke/authenticated.png', fullPage: true });
+
+            const authApiCalls = apiResponses.slice(authApiBefore);
+            const categoriesOk = authApiCalls.some(
+              (c) => c.url.includes('/Categories') && c.status === 200,
+            );
+            if (!categoriesOk) {
+              failures.push(
+                `No successful GET /Categories after login. API calls after login: ${JSON.stringify(authApiCalls).slice(0, 500)}`,
+              );
+            }
+
+            const errorUiVisible2 = await page.evaluate(() => {
+              const el = document.getElementById('blazor-error-ui');
+              return el && getComputedStyle(el).display !== 'none';
+            });
+            if (errorUiVisible2) failures.push('Blazor error UI visible on /categories');
+          }
+
+          console.log('All API responses:', JSON.stringify(apiResponses, null, 2));
+          console.log('Non-ignored bad responses:', JSON.stringify(badResponses, null, 2));
+          console.log('Console errors:', consoleErrors);
+
+          if (badResponses.length) failures.push(`Unexpected bad responses: ${JSON.stringify(badResponses)}`);
+          const apiFailed = apiResponses.filter((c) => c.status >= 500);
+          if (apiFailed.length) failures.push(`API 5xx during run: ${JSON.stringify(apiFailed)}`);
+
+          await browser.close();
+
+          if (failures.length) {
+            console.error('SMOKE FAILED:\n - ' + failures.join('\n - '));
+            process.exit(1);
+          }
+          console.log('SMOKE OK');
+          JS
+
+      - name: Run Playwright smoke
+        run: node smoke/smoke.mjs
+
+      - name: Upload smoke screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-smoke-screenshots
+          path: |
+            smoke/anonymous.png
+            smoke/authenticated.png
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Stop processes
+        if: always()
+        run: |
+          [ -f api-publish/api.pid ] && kill "$(cat api-publish/api.pid)" || true
+          [ -f web-publish/web.pid ] && kill "$(cat web-publish/web.pid)" || true
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-smoke-logs
+          path: |
+            api-publish/api.log
+            web-publish/web.log
+          retention-days: 3
+          if-no-files-found: ignore
+
+  smoke-report:
+    needs: [api-smoke, web-smoke, integration-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download publish artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: '*-publish'
+
+      - name: Fetch job timings
+        id: timings
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          jobs_json=$(gh api --paginate \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs")
+
+          duration_secs() {
+            local suffix="$1"
+            echo "$jobs_json" | jq -r --arg s "$suffix" '
+              [.jobs[]
+                | select(.name | endswith($s))
+                | select(.started_at and .completed_at)
+                | ((.completed_at | fromdateiso8601) - (.started_at | fromdateiso8601))
+              ] | first // 0
+            ' | awk '{printf "%d\n", $1}'
+          }
+
+          fmt() {
+            local s=${1:-0}
+            if [ "$s" -ge 60 ]; then
+              printf '%dm %02ds' $((s/60)) $((s%60))
+            else
+              printf '%ds' "$s"
+            fi
+          }
+
+          api_s=$(duration_secs '/ api-smoke')
+          web_s=$(duration_secs '/ web-smoke')
+          int_s=$(duration_secs '/ integration-smoke')
+          total_s=$(( ${api_s:-0} + ${web_s:-0} + ${int_s:-0} ))
+
+          {
+            echo "api_dur=$(fmt "$api_s")"
+            echo "web_dur=$(fmt "$web_s")"
+            echo "int_dur=$(fmt "$int_s")"
+            echo "total_dur=$(fmt "$total_s")"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "api=$api_s web=$web_s int=$int_s total=$total_s"
+
+      - name: Compute metrics
+        id: metrics
+        run: |
+          api_bytes=$(du -sb artifacts/api-publish 2>/dev/null | awk '{print $1}')
+          web_bytes=$(du -sb artifacts/web-publish 2>/dev/null | awk '{print $1}')
+          api_mb=$(awk "BEGIN{printf \"%.2f\", ${api_bytes:-0}/1048576}")
+          web_mb=$(awk "BEGIN{printf \"%.2f\", ${web_bytes:-0}/1048576}")
+
+          top_wasm=$(du -b artifacts/web-publish/_framework/*.wasm 2>/dev/null \
+            | sort -rn | head -5 \
+            | awk '{ sub("artifacts/web-publish/", "", $2); printf "- `%s` — %.2f MB\n", $2, $1/1048576 }')
+          [ -z "$top_wasm" ] && top_wasm="_(нет .wasm файлов)_"
+
+          {
+            echo "api_mb=$api_mb"
+            echo "web_mb=$web_mb"
+            echo "top_wasm<<EOF"
+            echo "$top_wasm"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build report
+        env:
+          API_RESULT: ${{ needs.api-smoke.result }}
+          WEB_RESULT: ${{ needs.web-smoke.result }}
+          INTEGRATION_RESULT: ${{ needs.integration-smoke.result }}
+          API_MB: ${{ steps.metrics.outputs.api_mb }}
+          WEB_MB: ${{ steps.metrics.outputs.web_mb }}
+          TOP_WASM: ${{ steps.metrics.outputs.top_wasm }}
+          API_DUR: ${{ steps.timings.outputs.api_dur }}
+          WEB_DUR: ${{ steps.timings.outputs.web_dur }}
+          INT_DUR: ${{ steps.timings.outputs.int_dur }}
+          TOTAL_DUR: ${{ steps.timings.outputs.total_dur }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_SHORT: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          mark() {
+            case "$1" in
+              success) echo "passed";;
+              skipped) echo "skipped";;
+              cancelled) echo "cancelled";;
+              *) echo "failed";;
+            esac
+          }
+
+          short_sha="${COMMIT_SHA:0:7}"
+          overall="success"
+          for r in "$API_RESULT" "$WEB_RESULT" "$INTEGRATION_RESULT"; do
+            if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
+              overall="failure"
+              break
+            fi
+          done
+
+          {
+            echo '## Publish smoke'
+            echo ''
+            echo "Результат: **$(mark "$overall")**"
+            echo ''
+            echo '| | |'
+            echo '| --- | --- |'
+            echo "| Прогон | [#${{ github.run_number }}]($RUN_URL) |"
+            echo "| Коммит | [\`$short_sha\`]($SERVER_URL/$REPO/commit/$COMMIT_SHA) |"
+            echo "| Ветка | \`$REF_NAME\` |"
+            echo "| Триггер | \`$EVENT_NAME\` |"
+            echo "| Автор | @$ACTOR |"
+            echo "| Суммарное время | $TOTAL_DUR |"
+            echo ''
+            echo '### Проверки'
+            echo ''
+            echo '| Проверка | Статус | Время | Что проверяет |'
+            echo '| --- | --- | ---: | --- |'
+            echo "| \`api-smoke\` | $(mark "$API_RESULT") | $API_DUR | publish, запуск, \`/alive\`, \`/health\`, \`/swagger\` |"
+            echo "| \`web-smoke\` | $(mark "$WEB_RESULT") | $WEB_DUR | publish WASM, отдача \`index.html\`, \`blazor.webassembly.js\` |"
+            echo "| \`integration-smoke\` | $(mark "$INTEGRATION_RESULT") | $INT_DUR | CORS preflight, OIDC discovery, Playwright (anonymous + authenticated) |"
+            echo ''
+            echo '### Размеры публикации'
+            echo ''
+            echo '| Артефакт | Размер |'
+            echo '| --- | ---: |'
+            echo "| API (\`Money.Api\`, net8.0) | $API_MB MB |"
+            echo "| Web (\`wwwroot\`, WASM) | $WEB_MB MB |"
+            echo ''
+            echo '<details>'
+            echo '<summary>Крупнейшие модули</summary>'
+            echo ''
+            echo "$TOP_WASM"
+            echo ''
+            echo '</details>'
+            echo ''
+            echo '### Артефакты'
+            echo ''
+            echo "- [\`integration-smoke-screenshots\`]($RUN_URL#artifacts) — скриншоты anonymous + authenticated"
+            echo "- [\`integration-smoke-logs\`, \`api-smoke-log\`]($RUN_URL#artifacts) — логи API и веб-сервера"
+            echo "- [\`api-publish\`, \`web-publish\`]($RUN_URL#artifacts) — опубликованные бинарники"
+            echo ''
+            echo "[Полный лог прогона]($RUN_URL)"
+          } > report.md
+
+          echo '--- report.md ---'
+          cat report.md
+
+      - name: Job summary
+        run: cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Sticky PR comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: publish-smoke
+          path: report.md

--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -134,7 +134,13 @@ jobs:
           echo "index.html not served"; exit 1
 
       - name: Check Blazor framework
-        run: curl -fsS -o /dev/null http://127.0.0.1:8080/_framework/blazor.webassembly.js
+        run: |
+          script_path=$(curl -fsS http://127.0.0.1:8080/index.html | grep -oE '_framework/blazor\.webassembly[^"]*\.js' | head -n 1)
+          if [ -z "$script_path" ]; then
+            echo "blazor.webassembly script not found in index.html"; exit 1
+          fi
+          echo "Checking /$script_path"
+          curl -fsS -o /dev/null "http://127.0.0.1:8080/$script_path"
 
       - name: Stop server
         if: always()
@@ -582,7 +588,7 @@ jobs:
             echo '| Проверка | Статус | Время | Что проверяет |'
             echo '| --- | --- | ---: | --- |'
             echo "| \`api-smoke\` | $(mark "$API_RESULT") | $API_DUR | publish, запуск, \`/alive\`, \`/health\`, \`/swagger\` |"
-            echo "| \`web-smoke\` | $(mark "$WEB_RESULT") | $WEB_DUR | publish WASM, отдача \`index.html\`, \`blazor.webassembly.js\` |"
+            echo "| \`web-smoke\` | $(mark "$WEB_RESULT") | $WEB_DUR | publish WASM, отдача \`index.html\`, \`blazor.webassembly*.js\` |"
             echo "| \`integration-smoke\` | $(mark "$INTEGRATION_RESULT") | $INT_DUR | CORS preflight, OIDC discovery, Playwright (anonymous + authenticated) |"
             echo ''
             echo '### Размеры публикации'
@@ -615,7 +621,7 @@ jobs:
         run: cat report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Sticky PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: publish-smoke

--- a/.run/Multi-Launch_ Money.run.xml
+++ b/.run/Multi-Launch_ Money.run.xml
@@ -1,0 +1,31 @@
+﻿<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Multi-Launch: Money" type="com.intellij.execution.configurations.multilaunch" factoryName="MultiLaunchConfiguration">
+    <rows>
+      <ExecutableRowSnapshot>
+        <option name="condition">
+          <ConditionSnapshot>
+            <option name="type" value="immediately" />
+          </ConditionSnapshot>
+        </option>
+        <option name="executable">
+          <ExecutableSnapshot>
+            <option name="id" value="runConfig:.NET Launch Settings Profile.Money.Api: https" />
+          </ExecutableSnapshot>
+        </option>
+      </ExecutableRowSnapshot>
+      <ExecutableRowSnapshot>
+        <option name="condition">
+          <ConditionSnapshot>
+            <option name="type" value="immediately" />
+          </ConditionSnapshot>
+        </option>
+        <option name="executable">
+          <ExecutableSnapshot>
+            <option name="id" value="runConfig:.NET Launch Settings Profile.Money.Web: https" />
+          </ExecutableSnapshot>
+        </option>
+      </ExecutableRowSnapshot>
+    </rows>
+    <method v="2" />
+  </configuration>
+</component>

--- a/Money.sln
+++ b/Money.sln
@@ -1,0 +1,148 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "backend", "backend", "{1AE8ACA6-933B-BF2A-3671-3E2EAC007D16}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Money.Api", "backend\Money.Api\Money.Api.csproj", "{485CF0BD-6587-4EEC-9800-66292E1A6567}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Money.Business", "backend\Money.Business\Money.Business.csproj", "{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Money.Common", "backend\Money.Common\Money.Common.csproj", "{26326A06-54EF-41A1-8397-978D8B25D4E9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Money.Data", "backend\Money.Data\Money.Data.csproj", "{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Money.Api.Tests", "backend\Money.Api.Tests\Money.Api.Tests.csproj", "{F371442F-BC51-4078-BE33-981C0976C401}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Money.ApiClient", "backend\Money.ApiClient\Money.ApiClient.csproj", "{B931F365-C664-4004-8F54-61A441846887}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "frontend", "frontend", "{CE609670-85B9-0D16-FB54-ED063D5D8A6D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Money.Web", "frontend\Money.Web\Money.Web.csproj", "{30C15360-124A-429A-BEB3-4E13CEABDEA1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A5DCC85B-7A7A-4A6B-9E3F-0C3B5B8D5A11}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		README.md = README.md
+		.github\workflows\backend.yml = .github\workflows\backend.yml
+		.github\workflows\frontend.yml = .github\workflows\frontend.yml
+		.github\workflows\integration.yml = .github\workflows\integration.yml
+		.github\workflows\main.yml = .github\workflows\main.yml
+		backend\Directory.Build.props = backend\Directory.Build.props
+		backend\Directory.Packages.props = backend\Directory.Packages.props
+		frontend\Directory.Build.props = frontend\Directory.Build.props
+		frontend\Directory.Packages.props = frontend\Directory.Packages.props
+		backend\.editorconfig = backend\.editorconfig
+		frontend\.editorconfig = frontend\.editorconfig
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Debug|x64.Build.0 = Debug|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Debug|x86.Build.0 = Debug|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Release|Any CPU.Build.0 = Release|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Release|x64.ActiveCfg = Release|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Release|x64.Build.0 = Release|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Release|x86.ActiveCfg = Release|Any CPU
+		{485CF0BD-6587-4EEC-9800-66292E1A6567}.Release|x86.Build.0 = Release|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Debug|x64.Build.0 = Debug|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Debug|x86.Build.0 = Debug|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Release|x64.ActiveCfg = Release|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Release|x64.Build.0 = Release|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Release|x86.ActiveCfg = Release|Any CPU
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3}.Release|x86.Build.0 = Release|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Debug|x64.Build.0 = Debug|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Debug|x86.Build.0 = Debug|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Release|x64.ActiveCfg = Release|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Release|x64.Build.0 = Release|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Release|x86.ActiveCfg = Release|Any CPU
+		{26326A06-54EF-41A1-8397-978D8B25D4E9}.Release|x86.Build.0 = Release|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Debug|x64.Build.0 = Debug|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Debug|x86.Build.0 = Debug|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Release|x64.ActiveCfg = Release|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Release|x64.Build.0 = Release|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Release|x86.ActiveCfg = Release|Any CPU
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB}.Release|x86.Build.0 = Release|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Debug|x64.Build.0 = Debug|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Debug|x86.Build.0 = Debug|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Release|x64.ActiveCfg = Release|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Release|x64.Build.0 = Release|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Release|x86.ActiveCfg = Release|Any CPU
+		{F371442F-BC51-4078-BE33-981C0976C401}.Release|x86.Build.0 = Release|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Debug|x64.Build.0 = Debug|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Debug|x86.Build.0 = Debug|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Release|x64.ActiveCfg = Release|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Release|x64.Build.0 = Release|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Release|x86.ActiveCfg = Release|Any CPU
+		{B931F365-C664-4004-8F54-61A441846887}.Release|x86.Build.0 = Release|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Debug|x64.Build.0 = Debug|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Debug|x86.Build.0 = Debug|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Release|x64.ActiveCfg = Release|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Release|x64.Build.0 = Release|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Release|x86.ActiveCfg = Release|Any CPU
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{485CF0BD-6587-4EEC-9800-66292E1A6567} = {1AE8ACA6-933B-BF2A-3671-3E2EAC007D16}
+		{E6A5D6A4-07CA-4C3A-9ED7-80C197C923B3} = {1AE8ACA6-933B-BF2A-3671-3E2EAC007D16}
+		{26326A06-54EF-41A1-8397-978D8B25D4E9} = {1AE8ACA6-933B-BF2A-3671-3E2EAC007D16}
+		{B984CEC0-B6F3-40E1-A1CA-5EABB73264DB} = {1AE8ACA6-933B-BF2A-3671-3E2EAC007D16}
+		{F371442F-BC51-4078-BE33-981C0976C401} = {1AE8ACA6-933B-BF2A-3671-3E2EAC007D16}
+		{B931F365-C664-4004-8F54-61A441846887} = {1AE8ACA6-933B-BF2A-3671-3E2EAC007D16}
+		{30C15360-124A-429A-BEB3-4E13CEABDEA1} = {CE609670-85B9-0D16-FB54-ED063D5D8A6D}
+	EndGlobalSection
+EndGlobal

--- a/Money.slnLaunch
+++ b/Money.slnLaunch
@@ -1,0 +1,17 @@
+﻿[
+  {
+    "Name": "Money",
+    "Projects": [
+      {
+        "Path": "backend\\Money.Api\\Money.Api.csproj",
+        "Action": "Start",
+        "DebugTarget": "https"
+      },
+      {
+        "Path": "frontend\\Money.Web\\Money.Web.csproj",
+        "Action": "Start",
+        "DebugTarget": "https"
+      }
+    ]
+  }
+]

--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -1,21 +1,21 @@
 ﻿<Project>
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <LangVersion>default</LangVersion>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>default</LangVersion>
 
-        <AnalysisLevel>latest</AnalysisLevel>
-        <AnalysisMode>All</AnalysisMode>
-        <!--<TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
-        <!--<CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>-->
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    </PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>All</AnalysisMode>
+    <!--<TreatWarningsAsErrors>true</TreatWarningsAsErrors>-->
+    <!--<CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>-->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
 
-    <ItemGroup Condition="'$(MSBuildProjectExtension)' != '.dcproj'">
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup Condition="'$(MSBuildProjectExtension)' != '.dcproj'">
+    <PackageReference Include="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.2" />
     <PackageVersion Include="OpenIddict.Client" Version="5.8.0" />
     <PackageVersion Include="OpenIddict.Client.AspNetCore" Version="5.8.0" />
     <PackageVersion Include="OpenIddict.Client.WebIntegration" Version="5.8.0" />

--- a/backend/Money.Api/Controllers/DebtsController.cs
+++ b/backend/Money.Api/Controllers/DebtsController.cs
@@ -159,6 +159,25 @@ public class DebtsController(DebtsService service) : ControllerBase
     }
 
     /// <summary>
+    /// Получить список держателей долга с фильтрацией по имени.
+    /// </summary>
+    /// <param name="offset">Сдвиг.</param>
+    /// <param name="count">Количество.</param>
+    /// <param name="name">Необязательный фильтр по имени.</param>
+    /// <param name="cancellationToken">Токен отмены запроса.</param>
+    /// <returns>Имена держателей долга.</returns>
+    [HttpGet("Owners/{offset:int:min(0)}/{count:int:range(1,100)}")]
+    [HttpGet("Owners/{offset:int:min(0)}/{count:int:range(1,100)}/{name:maxlength(100)}")]
+    [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetOwners(int offset, int count, string? name = null, CancellationToken cancellationToken = default)
+    {
+        var owners = await service.GetOwnersAsync(offset, count, name, cancellationToken);
+        return Ok(owners.Select(x => x.Name));
+    }
+
+    /// <summary>
     /// Простить долг.
     /// </summary>
     /// <param name="request">Данные для прощения долга.</param>

--- a/backend/Money.Api/Definitions/CoreLibDefinition.cs
+++ b/backend/Money.Api/Definitions/CoreLibDefinition.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Diagnostics.HealthChecks;
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Money.Api.Definitions;
 
@@ -11,12 +11,9 @@ public class CoreLibDefinition : AppDefinition
         builder.Services.AddHealthChecks()
             .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
 
-        builder.Services.AddServiceDiscovery();
-
         builder.Services.ConfigureHttpClientDefaults(http =>
         {
             http.AddStandardResilienceHandler();
-            http.AddServiceDiscovery();
         });
     }
 

--- a/backend/Money.Api/Money.Api.csproj
+++ b/backend/Money.Api/Money.Api.csproj
@@ -1,45 +1,44 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    </PropertyGroup>
+  <PropertyGroup>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-        <DocumentationFile>bin\Debug\Money.Api.xml</DocumentationFile>
-        <NoWarn>1701;1702;1591</NoWarn>
-    </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DocumentationFile>bin\Debug\Money.Api.xml</DocumentationFile>
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
-        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
-        <PackageReference Include="OpenIddict.Client" />
-        <PackageReference Include="OpenIddict.Client.AspNetCore" />
-        <PackageReference Include="OpenIddict.Client.WebIntegration" />
-        <PackageReference Include="ClosedXML" />
-        <PackageReference Include="EFCore.NamingConventions" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" NoWarn="NU1605" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" NoWarn="NU1605" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Identity.Core" />
-        <PackageReference Include="Microsoft.Identity.Web" />
-        <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" />
-        <PackageReference Include="Microsoft.OpenApi" />
-        <PackageReference Include="NLog.Schema" />
-        <PackageReference Include="NLog.Web.AspNetCore" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
-        <PackageReference Include="OpenIddict.AspNetCore" />
-        <PackageReference Include="OpenIddict.EntityFrameworkCore" />
-        <PackageReference Include="Swashbuckle.AspNetCore" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="OpenIddict.Client" />
+    <PackageReference Include="OpenIddict.Client.AspNetCore" />
+    <PackageReference Include="OpenIddict.Client.WebIntegration" />
+    <PackageReference Include="ClosedXML" />
+    <PackageReference Include="EFCore.NamingConventions" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" />
+    <PackageReference Include="Microsoft.Identity.Web" />
+    <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" />
+    <PackageReference Include="Microsoft.OpenApi" />
+    <PackageReference Include="NLog.Schema" />
+    <PackageReference Include="NLog.Web.AspNetCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="OpenIddict.AspNetCore" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Money.Business\Money.Business.csproj" />
-        <ProjectReference Include="..\Money.Common\Money.Common.csproj" />
-        <ProjectReference Include="..\Money.Data\Money.Data.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Money.Business\Money.Business.csproj" />
+    <ProjectReference Include="..\Money.Common\Money.Common.csproj" />
+    <ProjectReference Include="..\Money.Data\Money.Data.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/backend/Money.Api/Properties/launchSettings.json
+++ b/backend/Money.Api/Properties/launchSettings.json
@@ -1,33 +1,7 @@
 ﻿{
-  "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:5629",
-      "sslPort": 44367
-    }
-  },
+  "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7124;http://localhost:5249",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "aspire": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,

--- a/backend/Money.ApiClient/SubClients/DebtClient.cs
+++ b/backend/Money.ApiClient/SubClients/DebtClient.cs
@@ -52,6 +52,12 @@ public class DebtClient(MoneyClient apiClient) : ApiClientExecutor(apiClient)
         return GetAsync<DebtOwner[]>($"{BaseUri}/Owners");
     }
 
+    public Task<ApiClientResponse<string[]>> GetOwners(int offset, int count, string? name = null, CancellationToken token = default)
+    {
+        var postfixUri = string.IsNullOrWhiteSpace(name) ? string.Empty : $"/{Uri.EscapeDataString(name)}";
+        return GetAsync<string[]>($"{BaseUri}/Owners/{offset}/{count}{postfixUri}", token);
+    }
+
     public Task<ApiClientResponse> Forgive(int[] debtIds, int operationCategoryId, string? operationComment)
     {
         var request = new ForgiveRequest

--- a/backend/Money.Business/Services/DebtsService.cs
+++ b/backend/Money.Business/Services/DebtsService.cs
@@ -177,6 +177,57 @@ public class DebtsService(
         return dbDebtUsers;
     }
 
+    public Task<List<DebtOwner>> GetOwnersAsync(int offset, int count, string? name, CancellationToken cancellationToken = default)
+    {
+        var dbOwnerIdsByDebts = context.Debts
+            .IsUserEntity(environment.UserId)
+            .Select(x => x.OwnerId);
+
+        var query = context.DebtOwners
+            .IsUserEntity(environment.UserId)
+            .Where(x => dbOwnerIdsByDebts.Contains(x.Id));
+
+        var hasFilter = string.IsNullOrWhiteSpace(name) == false;
+
+        if (hasFilter)
+        {
+            var containsPattern = $"%{EscapeLikePattern(name!)}%";
+            query = query.Where(x => EF.Functions.ILike(x.Name, containsPattern, "\\"));
+        }
+
+        IOrderedQueryable<Data.Entities.DebtOwner> ordered;
+
+        if (hasFilter)
+        {
+            var startsWithPattern = $"{EscapeLikePattern(name!)}%";
+            ordered = query
+                .OrderByDescending(x => EF.Functions.ILike(x.Name, startsWithPattern, "\\"))
+                .ThenBy(x => x.Name);
+        }
+        else
+        {
+            ordered = query.OrderBy(x => x.Name);
+        }
+
+        return ordered
+            .Skip(offset)
+            .Take(count)
+            .Select(x => new DebtOwner
+            {
+                Id = x.Id,
+                Name = x.Name,
+            })
+            .ToListAsync(cancellationToken);
+    }
+
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal);
+    }
+
     public async Task ForgiveAsync(int[] debtIds, int operationCategoryId, string? operationComment, CancellationToken cancellationToken = default)
     {
         var entities = await context.Debts

--- a/frontend/Directory.Packages.props
+++ b/frontend/Directory.Packages.props
@@ -13,7 +13,6 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <PackageVersion Include="MudBlazor" Version="8.14.0" />
     <PackageVersion Include="MudBlazor.Translations" Version="2.6.0" />
     <PackageVersion Include="NCalc.DependencyInjection" Version="5.12.0" />

--- a/frontend/Directory.Packages.props
+++ b/frontend/Directory.Packages.props
@@ -9,12 +9,11 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.DotNet.HotReload.WebAssembly.Browser" Version="10.0.202" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="MudBlazor" Version="8.14.0" />
-    <PackageVersion Include="MudBlazor.Translations" Version="2.6.0" />
+    <PackageVersion Include="MudBlazor" Version="9.3.0" />
+    <PackageVersion Include="MudBlazor.Translations" Version="3.3.0" />
     <PackageVersion Include="NCalc.DependencyInjection" Version="5.12.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.4.0.108396" />
   </ItemGroup>

--- a/frontend/Money.Web/App.razor
+++ b/frontend/Money.Web/App.razor
@@ -1,5 +1,6 @@
-﻿<CascadingAuthenticationState>
-    <Router AppAssembly="@typeof(App).Assembly">
+﻿@using Money.Web.Pages
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(NotFound)">
         <Found Context="routeData">
             <AuthorizeRouteView DefaultLayout="@typeof(MainLayout)"
                                 RouteData="@routeData">
@@ -20,14 +21,5 @@
             <FocusOnNavigate RouteData="@routeData"
                              Selector="h1" />
         </Found>
-        <NotFound>
-            <PageTitle>Страница не найдена</PageTitle>
-            <LayoutView Layout="@typeof(MainLayout)">
-                <MudAlert Severity="Severity.Warning">
-                    Извините, но мы не можем найти запрашиваемую страницу.
-                    Пожалуйста, проверьте адрес или вернитесь на главную страницу.
-                </MudAlert>
-            </LayoutView>
-        </NotFound>
     </Router>
 </CascadingAuthenticationState>

--- a/frontend/Money.Web/Common/TreeViewExtensions.cs
+++ b/frontend/Money.Web/Common/TreeViewExtensions.cs
@@ -1,4 +1,4 @@
-namespace Money.Web.Common;
+﻿namespace Money.Web.Common;
 
 public static class TreeViewExtensions
 {
@@ -17,7 +17,7 @@ public static class TreeViewExtensions
             .ToList();
     }
 
-    public static void Filter<T>(this IEnumerable<TreeItemData<T>> treeItemData, string text)
+    public static void Filter<T>(this IEnumerable<ITreeItemData<T>> treeItemData, string text)
     {
         foreach (var itemData in treeItemData)
         {
@@ -30,7 +30,7 @@ public static class TreeViewExtensions
         }
     }
 
-    public static bool IsVisible<T>(this TreeItemData<T> treeItemData, string searchTerm)
+    public static bool IsVisible<T>(this ITreeItemData<T> treeItemData, string searchTerm)
     {
         if (treeItemData.HasChildren)
         {

--- a/frontend/Money.Web/Components/CarEvents/CarEventDialog.razor
+++ b/frontend/Money.Web/Components/CarEvents/CarEventDialog.razor
@@ -14,7 +14,7 @@
                          xs="12">
                     <MudTextField AdornmentColor="Color.Tertiary"
                                   AdornmentIcon="@Icons.Material.Rounded.Comment"
-                                  AutoGrow
+                                  Sizing="InputSizing.Auto"
                                   @bind-Value="Input.Title"
                                   For="@(() => Input.Title)"
                                   HelperText="Что произошло"
@@ -81,7 +81,7 @@
                          xs="12">
                     <MudTextField AdornmentColor="Color.Tertiary"
                                   AdornmentIcon="@Icons.Material.Rounded.Comment"
-                                  AutoGrow
+                                  Sizing="InputSizing.Auto"
                                   @bind-Value="Input.Comment"
                                   For="@(() => Input.Comment)"
                                   HelperText="Подробности"

--- a/frontend/Money.Web/Components/CategoryDialog.razor
+++ b/frontend/Money.Web/Components/CategoryDialog.razor
@@ -9,7 +9,7 @@
         </TitleContent>
         <DialogContent>
             <MudStack Spacing="3">
-                <MudTextField AutoGrow
+                <MudTextField Sizing="InputSizing.Auto"
                               @bind-Value="@Input.Name"
                               Clearable
                               For="@(() => Input.Name)"

--- a/frontend/Money.Web/Components/Debts/DebtCard.razor
+++ b/frontend/Money.Web/Components/Debts/DebtCard.razor
@@ -2,6 +2,7 @@
          Outlined
          Style="transition: transform 0.2s; box-shadow: 0 2px 4px rgba(0,0,0,0.1); height: 100%;"
          @onclick="OnMouseClicked"
+         @onmouseenter="OnMouseEnter"
          @onmouseleave="OnMouseLeave">
     <MudCardContent Style="padding: 8px 12px">
         <MudCollapse Expanded="_isExpandedSummary">
@@ -102,7 +103,7 @@
                 <MudIconButton Color="Color.Primary"
                                Icon="@Icons.Material.Rounded.Payment"
                                Size="Size.Small"
-                               OnClick="() => _idOpen = true"
+                               OnClick="ShowPaymentDialog"
                                Class="hover-scale" />
             </MudTooltip>
 

--- a/frontend/Money.Web/Components/Debts/DebtCard.razor.cs
+++ b/frontend/Money.Web/Components/Debts/DebtCard.razor.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Money.ApiClient;
 using System.ComponentModel.DataAnnotations;
@@ -83,15 +83,16 @@ public sealed partial class DebtCard : ComponentBase, IDisposable
         _isExpanded = !_isExpanded;
     }
 
+    private void OnMouseEnter()
+    {
+        StopCollapseTimer();
+    }
+
     private void OnMouseLeave()
     {
         if (_isExpanded == false)
         {
-            if (_isTimerRunning)
-            {
-                _debounceTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-            }
-
+            StopCollapseTimer();
             return;
         }
 
@@ -102,6 +103,24 @@ public sealed partial class DebtCard : ComponentBase, IDisposable
 
         _isTimerRunning = true;
         _debounceTimer?.Change(TimeSpan.FromMilliseconds(1000), Timeout.InfiniteTimeSpan);
+    }
+
+    private void StopCollapseTimer()
+    {
+        if (_isTimerRunning == false)
+        {
+            return;
+        }
+
+        _debounceTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        _isTimerRunning = false;
+    }
+
+    private void ShowPaymentDialog()
+    {
+        var remaining = Math.Max(0, Model.Sum - Model.PaySum);
+        Payment = new(DateTime.Now, remaining, string.Empty);
+        _idOpen = true;
     }
 
     private void OnTimerElapsed(object? state)

--- a/frontend/Money.Web/Components/Debts/DebtDialog.razor
+++ b/frontend/Money.Web/Components/Debts/DebtDialog.razor
@@ -48,7 +48,7 @@
                 <MudItem xs="12">
                     <MudTextField AdornmentColor="Color.Tertiary"
                                   AdornmentIcon="@Icons.Material.Rounded.Comment"
-                                  AutoGrow
+                                  Sizing="InputSizing.Auto"
                                   @bind-Value="Input.Comment"
                                   Counter="0"
                                   For="() => Input.Comment"

--- a/frontend/Money.Web/Components/Debts/DebtDialog.razor
+++ b/frontend/Money.Web/Components/Debts/DebtDialog.razor
@@ -10,12 +10,8 @@
         <DialogContent>
             <MudGrid>
                 <MudItem xs="12">
-                    <MudTextField AdornmentColor="Color.Tertiary"
-                                  AdornmentIcon="@Icons.Material.Rounded.Comment"
-                                  AutoGrow
-                                  @bind-Value="Input.OwnerName"
-                                  For="() => Input.OwnerName"
-                                  Label="Держатель" />
+                    <SmartDebtOwner @bind-Value="Input.OwnerName"
+                                    For="() => Input.OwnerName" />
                 </MudItem>
 
                 <MudItem xs="12">

--- a/frontend/Money.Web/Components/FastOperations/FastOperationDialog.razor
+++ b/frontend/Money.Web/Components/FastOperations/FastOperationDialog.razor
@@ -13,7 +13,7 @@
                          xs="12">
                     <MudTextField AdornmentColor="Color.Tertiary"
                                   AdornmentIcon="@Icons.Material.Rounded.Comment"
-                                  AutoGrow
+                                  Sizing="InputSizing.Auto"
                                   @bind-Value="Input.Name"
                                   For="@(() => Input.Name)"
                                   Label="Наименование" />
@@ -55,7 +55,7 @@
                          xs="12">
                     <MudTextField AdornmentColor="Color.Tertiary"
                                   AdornmentIcon="@Icons.Material.Rounded.Comment"
-                                  AutoGrow
+                                  Sizing="InputSizing.Auto"
                                   @bind-Value="Input.Comment"
                                   Counter="0"
                                   For="@(() => Input.Comment)"

--- a/frontend/Money.Web/Components/Operations/OperationDialog.razor
+++ b/frontend/Money.Web/Components/Operations/OperationDialog.razor
@@ -53,7 +53,7 @@
                      xs="12">
                 <MudTextField AdornmentColor="Color.Tertiary"
                               AdornmentIcon="@Icons.Material.Rounded.Comment"
-                              AutoGrow
+                              Sizing="InputSizing.Auto"
                               @bind-Value="Input.Comment"
                               Counter="0"
                               For="@(() => Input.Comment)"

--- a/frontend/Money.Web/Components/Operations/OperationsFilter.razor
+++ b/frontend/Money.Web/Components/Operations/OperationsFilter.razor
@@ -49,14 +49,16 @@
                 {
                     <MudDateRangePicker Adornment="Adornment.Start"
                                         AdornmentColor="Color.Tertiary"
-                                        @bind-DateRange="@DateRange"
                                         Clearable
                                         Color="Color.Tertiary"
                                         DateFormat="dd.MM.yyyy"
+                                        DateRange="DateRange"
+                                        DateRangeChanged="OnDateRangePickerChanged"
                                         Editable
                                         Label="Диапазон дат"
                                         Mask="@(new DateMask("dd.MM.yyyy"))"
                                         PickerVariant="PickerVariant.Inline"
+                                        @ref="_dateRangePicker"
                                         Rounded
                                         ShowWeekNumbers />
                 }
@@ -135,7 +137,8 @@
                                          Variant="Variant.Filled" />
                 </MudTooltip>
 
-                <MudTooltip Text="@(_showChangeCategorySelector ? "Отменить перенос" : "Перекинуть все отображённые на странице операции в выбранную категорию")">
+                <MudTooltip
+                    Text="@(_showChangeCategorySelector ? "Отменить перенос" : "Перекинуть все отображённые на странице операции в выбранную категорию")">
                     <MudToggleIconButton Color="Color.Tertiary"
                                          Icon="@Icons.Material.Rounded.MoveToInbox"
                                          Size="Size.Medium"

--- a/frontend/Money.Web/Components/Operations/OperationsFilter.razor
+++ b/frontend/Money.Web/Components/Operations/OperationsFilter.razor
@@ -67,7 +67,7 @@
                     <MudDatePicker Adornment="Adornment.Start"
                                    AdornmentColor="Color.Tertiary"
                                    AnchorOrigin="Origin.BottomLeft"
-                                   @bind-Date="@DateRange.Start"
+                                   @bind-Date="StartDate"
                                    Clearable
                                    Color="Color.Tertiary"
                                    DateFormat="dd.MM.yyyy"
@@ -79,7 +79,7 @@
                     <MudDatePicker Adornment="Adornment.Start"
                                    AdornmentColor="Color.Tertiary"
                                    AnchorOrigin="Origin.BottomRight"
-                                   @bind-Date="@DateRange.End"
+                                   @bind-Date="EndDate"
                                    Clearable
                                    Color="Color.Tertiary"
                                    DateFormat="dd.MM.yyyy"
@@ -109,7 +109,7 @@
             <MudTextField Adornment="Adornment.Start"
                           AdornmentColor="Color.Tertiary"
                           AdornmentIcon="@Icons.Material.Rounded.Comment"
-                          AutoGrow
+                          Sizing="InputSizing.Auto"
                           @bind-Value="Comment"
                           Clearable
                           Immediate

--- a/frontend/Money.Web/Components/Operations/OperationsFilter.razor.cs
+++ b/frontend/Money.Web/Components/Operations/OperationsFilter.razor.cs
@@ -1,4 +1,4 @@
-using Blazored.LocalStorage;
+﻿using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components;
 using Money.ApiClient;
 
@@ -6,6 +6,9 @@ namespace Money.Web.Components.Operations;
 
 public partial class OperationsFilter
 {
+    private const string DateRangeStartKey = nameof(DateRange) + ".Start";
+    private const string DateRangeEndKey = nameof(DateRange) + ".End";
+
     private static readonly List<DateInterval> DateIntervals =
     [
         new("День", "ий день", time => time, time => time, (time, direction) => time.AddDays(direction)),
@@ -39,6 +42,18 @@ public partial class OperationsFilter
     private string? Comment { get; set; }
     private string? Place { get; set; }
     private DateInterval? SelectedRange { get; set; }
+
+    private DateTime? StartDate
+    {
+        get => DateRange.Start;
+        set => _ = SetDateRangeAsync(new(value, DateRange.End));
+    }
+
+    private DateTime? EndDate
+    {
+        get => DateRange.End;
+        set => _ = SetDateRangeAsync(new(DateRange.Start, value));
+    }
 
     public async Task SearchAsync()
     {
@@ -86,20 +101,28 @@ public partial class OperationsFilter
 
     protected override async Task OnInitializedAsync()
     {
+        var savedStart = await StorageService.GetItemAsync<DateTime?>(DateRangeStartKey);
+        var savedEnd = await StorageService.GetItemAsync<DateTime?>(DateRangeEndKey);
+
+        if (savedStart.HasValue || savedEnd.HasValue)
+        {
+            DateRange = new(savedStart, savedEnd);
+        }
+
         var key = await StorageService.GetItemAsync<string?>(nameof(SelectedRange));
         var interval = DateIntervals.FirstOrDefault(interval => interval.DisplayName == key);
         await OnDateIntervalChanged(interval);
         await SearchAsync();
     }
 
-    private void OnDateRangePickerChanged(DateRange? value)
+    private async Task OnDateRangePickerChanged(DateRange? value)
     {
-        if (value is null && _dateRangePicker is { Converter.GetError: true })
+        if (value is null && _dateRangePicker is { ConversionError: true })
         {
             return;
         }
 
-        DateRange = value ?? new();
+        await SetDateRangeAsync(value ?? new DateRange());
     }
 
     private async Task OnDateIntervalChanged(DateInterval? value)
@@ -113,7 +136,14 @@ public partial class OperationsFilter
         }
     }
 
-    private Task UpdateDateRangeAsync(DateInterval value)
+    private async Task SetDateRangeAsync(DateRange value)
+    {
+        DateRange = value;
+        await StorageService.SetItemAsync(DateRangeStartKey, value.Start);
+        await StorageService.SetItemAsync(DateRangeEndKey, value.End);
+    }
+
+    private async Task UpdateDateRangeAsync(DateInterval value)
     {
         DateTime start;
 
@@ -130,19 +160,19 @@ public partial class OperationsFilter
             start = value.Start.Invoke(DateTime.Today);
         }
 
-        DateRange = new(start, value.End.Invoke(start));
-        return SearchAsync();
+        await SetDateRangeAsync(new(start, value.End.Invoke(start)));
+        await SearchAsync();
     }
 
-    private Task UpdateDateRangeAsync(Func<DateRange, DateRange> updateFunction)
+    private async Task UpdateDateRangeAsync(Func<DateRange, DateRange> updateFunction)
     {
         if (SelectedRange == null)
         {
-            return Task.CompletedTask;
+            return;
         }
 
-        DateRange = updateFunction.Invoke(DateRange);
-        return SearchAsync();
+        await SetDateRangeAsync(updateFunction.Invoke(DateRange));
+        await SearchAsync();
     }
 
     private Task ResetAsync()

--- a/frontend/Money.Web/Components/Operations/OperationsFilter.razor.cs
+++ b/frontend/Money.Web/Components/Operations/OperationsFilter.razor.cs
@@ -16,6 +16,7 @@ public partial class OperationsFilter
 
     private CategorySelector? _categorySelector;
     private CategorySelector? _changeCategorySelector;
+    private MudDateRangePicker? _dateRangePicker;
     private List<Operation>? _operations;
 
     private bool _showZeroDays;
@@ -89,6 +90,16 @@ public partial class OperationsFilter
         var interval = DateIntervals.FirstOrDefault(interval => interval.DisplayName == key);
         await OnDateIntervalChanged(interval);
         await SearchAsync();
+    }
+
+    private void OnDateRangePickerChanged(DateRange? value)
+    {
+        if (value is null && _dateRangePicker is { Converter.GetError: true })
+        {
+            return;
+        }
+
+        DateRange = value ?? new();
     }
 
     private async Task OnDateIntervalChanged(DateInterval? value)

--- a/frontend/Money.Web/Components/RegularOperations/RegularOperationDialog.razor
+++ b/frontend/Money.Web/Components/RegularOperations/RegularOperationDialog.razor
@@ -13,7 +13,7 @@
                          xs="12">
                     <MudTextField AdornmentColor="Color.Tertiary"
                                   AdornmentIcon="@Icons.Material.Rounded.Comment"
-                                  AutoGrow
+                                  Sizing="InputSizing.Auto"
                                   @bind-Value="Input.Name"
                                   For="@(() => Input.Name)"
                                   Label="Наименование" />
@@ -100,7 +100,7 @@
                          xs="12">
                     <MudTextField AdornmentColor="Color.Tertiary"
                                   AdornmentIcon="@Icons.Material.Rounded.Comment"
-                                  AutoGrow
+                                  Sizing="InputSizing.Auto"
                                   @bind-Value="Input.Comment"
                                   Counter="0"
                                   For="@(() => Input.Comment)"

--- a/frontend/Money.Web/Components/SmartDatePicker.razor
+++ b/frontend/Money.Web/Components/SmartDatePicker.razor
@@ -1,4 +1,4 @@
-@if (_isDatePickerVisible)
+﻿@if (_isDatePickerVisible)
 {
     <div style="position: relative;">
         <MudDatePicker @ref="_datePicker"
@@ -15,7 +15,7 @@
                        OnClick="SwitchToTextInputAsync"
                        Size="Size.Small"
                        Style="position: absolute; right: 24px; top: 65%; transform: translateY(-50%); z-index: 1000;"
-                       Title="Текстовый ввод" />
+                       title="Текстовый ввод" />
         @* TODO: По идее Style и сама кнопка не нужна, т. к. всегда при закрытии переключится, но на всякий случай *@
     </div>
 }

--- a/frontend/Money.Web/Components/SmartDebtOwner.razor
+++ b/frontend/Money.Web/Components/SmartDebtOwner.razor
@@ -1,0 +1,45 @@
+﻿<div style="position: relative;">
+    <MudTextField Adornment="@Adornment"
+                  AdornmentColor="Color.Tertiary"
+                  AdornmentIcon="@Icons.Material.Rounded.Person"
+                  Clearable
+                  For="@For"
+                  Immediate
+                  Label="Держатель"
+                  @onfocus="OnFocusAsync"
+                  OnKeyDown="@OnKeyDownAsync"
+                  OnBlur="@OnBlurAsync"
+                  T="string"
+                  Value="@_currentText"
+                  ValueChanged="@OnTextChangedAsync" />
+
+    @if (_showSuggestions && _suggestions.Any())
+    {
+        <MudPaper Class="autocomplete-suggestions"
+                  Elevation="8"
+                  Style="position: absolute; top: 100%; left: 0; right: 0; max-height: 300px; overflow-y: auto; z-index: 1300; margin-top: 4px;">
+            <MudList Dense
+                     T="string">
+                @for (var i = 0; i < _suggestions.Count; i++)
+                {
+                    var index = i;
+                    var suggestion = _suggestions[i];
+                    var isSelected = index == _selectedIndex;
+                    var itemStyle = isSelected ? "background-color: var(--mud-palette-action-default-hover);" : string.Empty;
+                    <MudListItem OnClick="@(() => SelectSuggestionAsync(suggestion))"
+                                 Style="@itemStyle"
+                                 T="string">
+                        @suggestion
+                    </MudListItem>
+                }
+            </MudList>
+        </MudPaper>
+    }
+
+    @if (_isLoading)
+    {
+        <MudProgressLinear Color="Color.Tertiary"
+                           Indeterminate
+                           Style="position: absolute; bottom: 0; left: 0; right: 0;" />
+    }
+</div>

--- a/frontend/Money.Web/Components/SmartDebtOwner.razor.cs
+++ b/frontend/Money.Web/Components/SmartDebtOwner.razor.cs
@@ -1,0 +1,224 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using System.Linq.Expressions;
+using Timer = System.Timers.Timer;
+
+namespace Money.Web.Components;
+
+public sealed partial class SmartDebtOwner(DebtOwnerService debtOwnerService) : IDisposable
+{
+    private string? _currentText;
+    private List<string> _suggestions = [];
+    private bool _showSuggestions;
+    private bool _isLoading;
+    private int _selectedIndex = -1;
+    private bool _isFocused;
+    private CancellationTokenSource? _searchCancellationTokenSource;
+    private Timer? _debounceTimer;
+
+    /// <summary>
+    ///     <inheritdoc cref="MudAutocomplete{T}" />
+    /// </summary>
+    [Parameter]
+    public string? Value { get; set; }
+
+    /// <summary>
+    ///     <inheritdoc cref="MudAutocomplete{T}" />
+    /// </summary>
+    [Parameter]
+    public EventCallback<string?> ValueChanged { get; set; }
+
+    /// <summary>
+    ///     <inheritdoc cref="MudAutocomplete{T}" />
+    /// </summary>
+    [Parameter]
+    public Expression<Func<string?>>? For { get; set; }
+
+    /// <summary>
+    ///     <inheritdoc cref="MudAutocomplete{T}" />
+    /// </summary>
+    [Parameter]
+    public Adornment Adornment { get; set; } = Adornment.End;
+
+    /// <summary>
+    ///     <inheritdoc cref="MudAutocomplete{T}" />
+    /// </summary>
+    [Parameter]
+    public int DebounceInterval { get; set; } = 300;
+
+    [Inject]
+    private ILogger<SmartDebtOwner> Logger { get; set; } = null!;
+
+    public void Dispose()
+    {
+        _searchCancellationTokenSource?.Dispose();
+        _debounceTimer?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    protected override void OnParametersSet()
+    {
+        _currentText = Value;
+    }
+
+    private Task OnFocusAsync(FocusEventArgs focusEventArgs)
+    {
+        _ = focusEventArgs;
+        _isFocused = true;
+        _selectedIndex = -1;
+
+        _debounceTimer?.Stop();
+        _debounceTimer?.Dispose();
+        _debounceTimer = null;
+
+        return LoadSuggestionsAsync();
+    }
+
+    private Task OnKeyDownAsync(KeyboardEventArgs args)
+    {
+        if (args.Key == "ArrowDown")
+        {
+            if (!_showSuggestions || _suggestions.Count <= 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            _selectedIndex = Math.Min(_selectedIndex + 1, _suggestions.Count - 1);
+            StateHasChanged();
+        }
+        else if (args.Key == "ArrowUp")
+        {
+            if (!_showSuggestions || _suggestions.Count <= 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            _selectedIndex = Math.Max(_selectedIndex - 1, -1);
+            StateHasChanged();
+        }
+        else if (args.Key == "Enter")
+        {
+            if (_showSuggestions && _selectedIndex >= 0 && _selectedIndex < _suggestions.Count)
+            {
+                return SelectSuggestionAsync(_suggestions[_selectedIndex]);
+            }
+
+            return AcceptCurrentTextAsync();
+        }
+        else if (args.Key == "Escape")
+        {
+            _showSuggestions = false;
+            _selectedIndex = -1;
+            StateHasChanged();
+        }
+        else if (args.Key == "Tab")
+        {
+            if (!_showSuggestions || _suggestions.Count <= 0 || _selectedIndex < 0)
+            {
+                return AcceptCurrentTextAsync();
+            }
+
+            return SelectSuggestionAsync(_suggestions[_selectedIndex]);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnTextChangedAsync(string? value)
+    {
+        _currentText = value;
+        _selectedIndex = -1;
+        StartSearchDebounced();
+        return Task.CompletedTask;
+    }
+
+    private void StartSearchDebounced()
+    {
+        if (!_isFocused)
+        {
+            return;
+        }
+
+        _debounceTimer?.Stop();
+        _debounceTimer?.Dispose();
+
+        _debounceTimer = new(DebounceInterval);
+        _debounceTimer.Elapsed += async (_, _) =>
+        {
+            await InvokeAsync(LoadSuggestionsAsync);
+        };
+
+        _debounceTimer.AutoReset = false;
+        _debounceTimer.Start();
+    }
+
+    private async Task LoadSuggestionsAsync()
+    {
+        if (_searchCancellationTokenSource != null)
+        {
+            await _searchCancellationTokenSource.CancelAsync();
+            _searchCancellationTokenSource.Dispose();
+        }
+
+        _searchCancellationTokenSource = new();
+
+        _isLoading = true;
+        _selectedIndex = -1;
+        StateHasChanged();
+
+        try
+        {
+            var searchValue = _currentText;
+            var owners = await debtOwnerService.SearchOwner(searchValue, _searchCancellationTokenSource.Token);
+            _suggestions = [.. owners];
+            _showSuggestions = _isFocused && _suggestions.Count > 0;
+        }
+        catch (OperationCanceledException)
+        {
+            _showSuggestions = false;
+            _selectedIndex = -1;
+        }
+        catch (Exception exception)
+        {
+            Logger.LogWarning(exception, "Не удалось загрузить подсказки держателей долга");
+            _suggestions.Clear();
+            _showSuggestions = false;
+        }
+        finally
+        {
+            _isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task SelectSuggestionAsync(string suggestion)
+    {
+        _currentText = suggestion;
+        _showSuggestions = false;
+        _selectedIndex = -1;
+        await ValueChanged.InvokeAsync(_currentText);
+        StateHasChanged();
+    }
+
+    private async Task AcceptCurrentTextAsync()
+    {
+        _showSuggestions = false;
+        _selectedIndex = -1;
+        await ValueChanged.InvokeAsync(_currentText);
+        StateHasChanged();
+    }
+
+    private async Task OnBlurAsync()
+    {
+        _isFocused = false;
+        _debounceTimer?.Stop();
+        _debounceTimer?.Dispose();
+        _debounceTimer = null;
+
+        await Task.Delay(200);
+        _showSuggestions = false;
+        _selectedIndex = -1;
+        await ValueChanged.InvokeAsync(_currentText);
+        StateHasChanged();
+    }
+}

--- a/frontend/Money.Web/Money.Web.csproj
+++ b/frontend/Money.Web/Money.Web.csproj
@@ -4,12 +4,11 @@
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <EmccMaximumHeapSize>268435456</EmccMaximumHeapSize>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)'!='DEBUG'">
     <RunAOTCompilation>true</RunAOTCompilation>
   </PropertyGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" />
@@ -21,7 +20,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" />
-    <PackageReference Include="Microsoft.DotNet.HotReload.WebAssembly.Browser" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/frontend/Money.Web/Money.Web.csproj
+++ b/frontend/Money.Web/Money.Web.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
     <PackageReference Include="MudBlazor" />
     <PackageReference Include="MudBlazor.Translations" />
     <PackageReference Include="NCalc.DependencyInjection" />

--- a/frontend/Money.Web/Pages/Cars.razor
+++ b/frontend/Money.Web/Pages/Cars.razor
@@ -25,7 +25,6 @@
          ApplyEffectsToContainer
          Elevation="4"
          HeaderPosition="TabHeaderPosition.Before"
-         PanelClass="px-4 py-6"
          Rounded>
     <Header>
         <MudTooltip Text="Добавить авто">
@@ -45,7 +44,7 @@
                     <MudTextField Adornment="Adornment.Start"
                                   AdornmentColor="Color.Tertiary"
                                   AdornmentIcon="@Icons.Material.Rounded.Comment"
-                                  AutoGrow
+                                  Sizing="InputSizing.Auto"
                                   @bind-Value="_addCarName"
                                   Clearable
                                   Immediate
@@ -75,6 +74,7 @@
         @foreach (var car in _cars)
         {
             <MudTabPanel ID="@car.Id"
+                         PanelClass="px-4 py-6"
                          ShowCloseIcon="false"
                          Text="@car.Name">
                 <MudStack AlignItems="AlignItems.Center"

--- a/frontend/Money.Web/Pages/Categories.razor.cs
+++ b/frontend/Money.Web/Pages/Categories.razor.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Money.ApiClient;
 
 namespace Money.Web.Pages;
@@ -124,8 +124,14 @@ public partial class Categories
             return;
         }
 
-        parentItem.Children ??= [];
-        parentItem.Children.Add(addedItem);
+        if (parentItem.Children is List<TreeItemData<Category>> children)
+        {
+            children.Add(addedItem);
+        }
+        else
+        {
+            parentItem.Children = new List<TreeItemData<Category>> { addedItem };
+        }
     }
 
     private void SortTree(int operationTypeId)
@@ -134,9 +140,10 @@ public partial class Categories
         StateHasChanged();
     }
 
-    private List<TreeItemData<Category>> SortChildren(IEnumerable<TreeItemData<Category>> categories)
+    private List<TreeItemData<Category>> SortChildren(IEnumerable<ITreeItemData<Category>> categories)
     {
         var sortedCategories = categories
+            .Cast<TreeItemData<Category>>()
             .OrderBy(item => item.Value?.Order == null)
             .ThenBy(item => item.Value?.Order)
             .ThenBy(item => item.Value?.Name)
@@ -153,14 +160,14 @@ public partial class Categories
         return sortedCategories;
     }
 
-    private TreeItemData<Category>? SearchParentTreeItem(List<TreeItemData<Category>>? list, int id)
+    private TreeItemData<Category>? SearchParentTreeItem(IReadOnlyCollection<ITreeItemData<Category>>? list, int id)
     {
         if (list == null)
         {
             return null;
         }
 
-        foreach (var item in list)
+        foreach (var item in list.OfType<TreeItemData<Category>>())
         {
             if (item.Value?.Id == id)
             {

--- a/frontend/Money.Web/Pages/Debts.razor
+++ b/frontend/Money.Web/Pages/Debts.razor
@@ -86,7 +86,7 @@
                 <MudTextField Adornment="Adornment.Start"
                               AdornmentColor="Color.Tertiary"
                               AdornmentIcon="@Icons.Material.Rounded.Comment"
-                              AutoGrow
+                              Sizing="InputSizing.Auto"
                               @bind-Value="_forgiveComment"
                               Clearable
                               Immediate

--- a/frontend/Money.Web/Pages/Home.razor.cs
+++ b/frontend/Money.Web/Pages/Home.razor.cs
@@ -1,9 +1,15 @@
-namespace Money.Web.Pages;
+﻿namespace Money.Web.Pages;
 
 public partial class Home
 {
     private readonly List<VersionHistoryEntry> _versionHistory =
     [
+        new("1.3.1", new(2026, 4, 22), [
+            new("Добавлена подсказка ранее заполненных держателей при создании долга.", ChangeType.Feature),
+            new("Исправлено сворачивание окна оплаты долга при наведении курсора.", ChangeType.BugFix),
+            new("Сумма платежа предзаполняется остатком долга.", ChangeType.UiUx),
+        ]),
+
         new("1.3.0", new(2026, 4, 21), [
             new("Исправлена ошибка со сдвигом даты операций, долгов и событий на предыдущий день в часовых поясах к востоку от UTC.", ChangeType.BugFix),
             new("Переход на .NET 10.", ChangeType.Improvement),

--- a/frontend/Money.Web/Pages/Home.razor.cs
+++ b/frontend/Money.Web/Pages/Home.razor.cs
@@ -4,6 +4,10 @@ public partial class Home
 {
     private readonly List<VersionHistoryEntry> _versionHistory =
     [
+        new("1.3.2", new(2026, 4, 22), [
+            new("Исправлен сброс выбранного диапазона дат в фильтре операций при уходе на другую страницу и возврате обратно.", ChangeType.BugFix),
+        ]),
+
         new("1.3.1", new(2026, 4, 22), [
             new("Добавлена подсказка ранее заполненных держателей при создании долга.", ChangeType.Feature),
             new("Исправлено сворачивание окна оплаты долга при наведении курсора.", ChangeType.BugFix),
@@ -244,7 +248,7 @@ public partial class Home
 
     private string GetCurrentVersion()
     {
-        return _versionHistory.FirstOrDefault()?.Version ?? "1.3.0";
+        return _versionHistory.FirstOrDefault()?.Version ?? "unknown";
     }
 
     private Color GetVersionColor(VersionHistoryEntry entry)

--- a/frontend/Money.Web/Pages/NotFound.razor
+++ b/frontend/Money.Web/Pages/NotFound.razor
@@ -1,0 +1,9 @@
+﻿@page "/not-found"
+@layout MainLayout
+
+<PageTitle>Страница не найдена</PageTitle>
+
+<MudAlert Severity="Severity.Warning">
+    Извините, но мы не можем найти запрашиваемую страницу.
+    Пожалуйста, проверьте адрес или вернитесь на главную страницу.
+</MudAlert>

--- a/frontend/Money.Web/Program.cs
+++ b/frontend/Money.Web/Program.cs
@@ -1,7 +1,6 @@
-using Blazored.LocalStorage;
+﻿using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Microsoft.Extensions.ServiceDiscovery;
 using Money.ApiClient;
 using Money.Web.Services.Authentication;
 using MudBlazor.Services;
@@ -10,20 +9,23 @@ using NCalc.DependencyInjection;
 using System.Globalization;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
-var apiUri = new Uri($"https://{builder.Configuration["Services:api:https:0"]}");
+var apiEndpoint = builder.Configuration["Services:api:https:0"]
+                  ?? throw new InvalidOperationException("Services:api:https:0 is not configured");
 
-builder.Services.AddServiceDiscovery();
+Uri apiUri;
+if (Uri.TryCreate(apiEndpoint, UriKind.Absolute, out var parsed)
+    && (parsed.Scheme == Uri.UriSchemeHttp || parsed.Scheme == Uri.UriSchemeHttps))
+{
+    apiUri = parsed;
+}
+else
+{
+    apiUri = new($"https://{apiEndpoint}");
+}
 
 builder.Services.ConfigureHttpClientDefaults(http =>
 {
     http.AddStandardResilienceHandler();
-    http.AddServiceDiscovery();
-});
-
-builder.Services.Configure<ConfigurationServiceEndpointProviderOptions>(static options =>
-{
-    options.SectionName = "Services";
-    options.ShouldApplyHostNameMetadata = static _ => true;
 });
 
 builder.RootComponents.Add<App>("#app");

--- a/frontend/Money.Web/Program.cs
+++ b/frontend/Money.Web/Program.cs
@@ -54,6 +54,7 @@ builder.Services.AddScoped<FastOperationService>();
 builder.Services.AddScoped<PlaceService>();
 builder.Services.AddScoped<RegularOperationService>();
 builder.Services.AddScoped<DebtService>();
+builder.Services.AddScoped<DebtOwnerService>();
 builder.Services.AddScoped<CarService>();
 builder.Services.AddScoped<CarEventService>();
 

--- a/frontend/Money.Web/Properties/launchSettings.json
+++ b/frontend/Money.Web/Properties/launchSettings.json
@@ -1,33 +1,7 @@
-{
-  "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:13103",
-      "sslPort": 44338
-    }
-  },
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:7168;http://localhost:5028",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "aspire": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,

--- a/frontend/Money.Web/Services/DebtOwnerService.cs
+++ b/frontend/Money.Web/Services/DebtOwnerService.cs
@@ -1,0 +1,67 @@
+﻿using Money.ApiClient;
+
+namespace Money.Web.Services;
+
+public class DebtOwnerService(MoneyClient moneyClient)
+{
+    private const int CacheCapacity = 64;
+
+    private readonly LinkedList<string> _cacheOrder = [];
+    private readonly Dictionary<string, string[]> _cache = [];
+    private string _lastSearchedValue = string.Empty;
+
+    public async Task<IEnumerable<string>> SearchOwner(string? value, CancellationToken token = default)
+    {
+        value ??= string.Empty;
+
+        if (_cache.TryGetValue(value, out var cachedResults))
+        {
+            return cachedResults;
+        }
+
+        var diff = value.Length - _lastSearchedValue.Length;
+
+        if (diff > 0
+            && value.StartsWith(_lastSearchedValue, StringComparison.OrdinalIgnoreCase)
+            && _cache.TryGetValue(_lastSearchedValue, out var cachedOwners)
+            && cachedOwners.Length == 0)
+        {
+            return [];
+        }
+
+        var response = await moneyClient.Debts.GetOwners(0, 10, value, token);
+
+        if (response.Content == null)
+        {
+            return [];
+        }
+
+        var owners = response.Content;
+
+        AddToCache(value, owners);
+        _lastSearchedValue = value;
+
+        return owners;
+    }
+
+    private void AddToCache(string key, string[] value)
+    {
+        if (_cache.ContainsKey(key))
+        {
+            _cacheOrder.Remove(key);
+        }
+        else if (_cache.Count >= CacheCapacity)
+        {
+            var oldest = _cacheOrder.First;
+
+            if (oldest != null)
+            {
+                _cache.Remove(oldest.Value);
+                _cacheOrder.RemoveFirst();
+            }
+        }
+
+        _cache[key] = value;
+        _cacheOrder.AddLast(key);
+    }
+}

--- a/frontend/Money.Web/wwwroot/css/app.css
+++ b/frontend/Money.Web/wwwroot/css/app.css
@@ -1,13 +1,53 @@
+﻿html, body {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+h1:focus {
+    outline: none;
+}
+
+a, .btn-link {
+    color: #0071c1;
+}
+
+.btn-primary {
+    color: #fff;
+    border-color: #1861ac;
+    background-color: #1b6ec2;
+}
+
+.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
+    box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
+}
+
+.content {
+    padding-top: 1.1rem;
+}
+
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid {
+    outline: 1px solid red;
+}
+
+.validation-message {
+    color: red;
+}
+
 #blazor-error-ui {
     position: fixed;
     z-index: 1000;
     bottom: 0;
     left: 0;
     display: none;
+    box-sizing: border-box;
     width: 100%;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;
     background: lightyellow;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    color-scheme: light only;
 }
 
 #blazor-error-ui .dismiss {
@@ -25,6 +65,29 @@
 
 .blazor-error-boundary::after {
     content: "An error has occurred."
+}
+
+.loading-progress {
+    position: absolute;
+    display: block;
+    width: 8rem;
+    height: 8rem;
+    margin: 0 auto 0 auto;
+    inset: 20vh 0 auto 0;
+}
+
+.loading-progress circle {
+    transform: rotate(-90deg);
+    transform-origin: 50% 50%;
+    fill: none;
+    stroke: #e0e0e0;
+    stroke-width: 0.6rem;
+}
+
+.loading-progress circle:last-child {
+    transition: stroke-dasharray 0.05s ease-in-out;
+    stroke: #1b6ec2;
+    stroke-dasharray: calc(3.141 * var(--blazor-load-percentage, 0%) * 0.8), 500%;
 }
 
 .loading-progress-text {
@@ -51,9 +114,22 @@
     background-size: cover;
 }
 
+code {
+    color: #c02d76;
+}
+
 .large-text {
     overflow: hidden;
     max-width: 100%;
     white-space: nowrap;
     text-overflow: ellipsis;
+}
+
+.form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
+    text-align: end;
+    color: var(--bs-secondary-color);
+}
+
+.form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
+    text-align: start;
 }

--- a/frontend/Money.Web/wwwroot/index.html
+++ b/frontend/Money.Web/wwwroot/index.html
@@ -28,6 +28,9 @@
           rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css"
           rel="stylesheet" />
+
+    <link id="webassembly" rel="preload" />
+    <script type="importmap"></script>
 </head>
 
 <body>
@@ -41,11 +44,11 @@
         Извините, произошла ошибка.
         Пожалуйста, попробуйте снова.
         <a class="reload"
-           href="">Перезагрузить</a>
+           href=".">Перезагрузить</a>
         <a class="dismiss">Закрыть</a>
     </div>
     <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 
     <script src="js/chart.min.js"></script>


### PR DESCRIPTION
Исправлен сброс диапазона дат в фильтре операций 
- Исправлен NullReferenceException при очистке MudDateRangePicker
- Защищён текущий диапазон от сброса при невалидном вводе даты
- Заменён @bind-DateRange на явный DateRangeChanged

Удалён Microsoft.Extensions.ServiceDiscovery 
- Убран пакет из backend и frontend Directory.Packages.props и csproj
- Убраны вызовы AddServiceDiscovery в CoreLibDefinition и WASM Program
- Безопасный разбор apiUri с проверкой схемы http/https
- Переформатирован Money.Api.csproj, отступы 2 пробела

Подсказка держателя долга MaxNagibator#81 
- Добавлен эндпоинт GetOwners с пагинацией и фильтром ILike по имени
- Реализован приоритет StartsWith в сортировке с экранированием спецсимволов
- Добавлен метод GetOwners в DebtClient
- Реализован компонент SmartDebtOwner с дебаунсом и навигацией клавишами
- Реализован DebtOwnerService с LRU-кэшем на 64 ключа
- DebtDialog переведён на SmartDebtOwner, сервис зарегистрирован в DI

Косяки оплаты долга MaxNagibator#80 
- Таймер сворачивания гасится на @onMouseEnter
- Сброс _isTimerRunning вынесен в StopCollapseTimer
- Сумма платежа предзаполняется остатком долга

Smoke-проверка публикации в CI 
- Добавлен workflow publish-smoke с api-smoke, web-smoke и integration-smoke
- В integration-smoke запущены CORS preflight, OIDC discovery и Playwright сценарии anonymous + authenticated
- Добавлен sticky PR-комментарий с размерами артефактов, временем и статусом
- В main.yml подключён publish-smoke как job
- Для Debug-сборки веба отключены AOT и сжатие Blazor
- Нормализованы хвостовые пробелы в шагах workflow

Корневой Money.sln и мульти-запуск в Rider 
- Добавлен корневой Money.sln с объединёнными backend и frontend
- Добавлен Money.slnLaunch с одновременным стартом API и Web
- Добавлена Rider multi-launch конфигурация в .run

Обновлённая история изменений

Переход на MudBlazor 9.3.0 
- Добавлено сохранение диапазона дат фильтра операций в LocalStorage, выбор сохраняется между страницами
- Обновлены пакеты MudBlazor до 9.3.0 и MudBlazor.Translations до 3.3.0
- Адаптирован TreeView API под IReadOnlyCollection<ITreeItemData<T>>
- Обработчик DateRangePicker переведён на ConversionError вместо Converter.GetError
- Добавлены локальные StartDate/EndDate вместо привязки к Range<T>.Start/End (в v9 стали read-only)
- Заменён AutoGrow на Sizing="InputSizing.Auto" в текстовых полях
- Перенесён PanelClass с MudTabs на MudTabPanel в странице авто
- Удалён дубликат Microsoft.DotNet.HotReload.WebAssembly.Browser из csproj

Приборка шаблонов и launch-профилей 
- Убраны профили IIS Express и aspire из launchSettings.json бэка и фронта
- Выполнен переход на NotFoundPage с выделением NotFound.razor (шаблон .NET 10)
- Добавлены preload и fingerprinting WebAssembly в index.html
- Восстановлены дефолтные стили .NET 10 в app.css
- Переформатирован backend/Directory.Build.props

Починка publish-smoke под .NET 10 и cross-repo PR 
- Путь к blazor.webassembly.js извлекается из index.html, поддерживается fingerprint-шаблон
- Sticky PR-комментарий пропускается для cross-repo PR (GITHUB_TOKEN без прав на запись)
- Обновлена текстовка web-smoke в сводке