### PR TITLE
Продолжение починок

### DIFF
--- a/frontend/Money.Web/Components/Operations/OperationDialog.razor
+++ b/frontend/Money.Web/Components/Operations/OperationDialog.razor
@@ -81,12 +81,14 @@
                   Justify="Justify.SpaceBetween"
                   Row>
             <MudButton Color="Color.Error"
-                       OnClick=" () => ToggleOpen()">
+                       OnClick=" () => ToggleOpen()"
+                       tabindex="-1">
                 Закрыть
             </MudButton>
             <MudButton OnClick="SubmitAsync"
                        Color="Color.Tertiary"
-                       Variant="Variant.Filled">
+                       Variant="Variant.Filled"
+                       Class="save-button">
                 Сохранить
             </MudButton>
         </MudStack>
@@ -119,5 +121,11 @@
 
     .suggested-chip-close:hover {
         color: var(--mud-palette-error) !important;
+    }
+
+    .save-button:focus-visible {
+        outline: 2px solid var(--mud-palette-tertiary-darken);
+        outline-offset: 3px;
+        box-shadow: 0 0 0 4px rgba(var(--mud-palette-tertiary-rgb), 0.25);
     }
 </style>

--- a/frontend/Money.Web/Components/Operations/OperationDialog.razor
+++ b/frontend/Money.Web/Components/Operations/OperationDialog.razor
@@ -43,9 +43,18 @@
                              Color="Color.Tertiary"
                              Variant="Variant.Outlined"
                              Icon="@Icons.Material.Rounded.AutoAwesome"
-                             OnClose="@(_ => ClearSuggestion())"
-                             Class="mt-1">
-                        Подставлено: @_suggestedCategory.Name
+                             Class="mt-1 suggested-chip">
+                        <MudTooltip Text="@($"Подставлено: {_suggestedCategory?.Name}")"
+                                    Placement="Placement.Top">
+                            <span class="suggested-chip-label">@_suggestedCategory?.Name</span>
+                        </MudTooltip>
+                        <MudTooltip Text="Убрать подстановку"
+                                    Placement="Placement.Top">
+                            <MudIconButton Icon="@Icons.Material.Rounded.Close"
+                                           Size="Size.Small"
+                                           OnClick="ClearSuggestion"
+                                           Class="suggested-chip-close" />
+                        </MudTooltip>
                     </MudChip>
                 }
             </MudItem>
@@ -87,5 +96,28 @@
 <style>
     .pop-over {
         max-width: 600px !important;
+    }
+
+    .suggested-chip {
+        max-width: 100%;
+    }
+
+    .suggested-chip-label {
+        display: inline-block;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        vertical-align: middle;
+    }
+
+    .suggested-chip-close {
+        margin-left: 4px;
+        padding: 2px !important;
+        transition: color 0.15s ease;
+    }
+
+    .suggested-chip-close:hover {
+        color: var(--mud-palette-error) !important;
     }
 </style>

--- a/frontend/Money.Web/Components/SmartDatePicker.razor
+++ b/frontend/Money.Web/Components/SmartDatePicker.razor
@@ -28,7 +28,6 @@ else
                   Clearable
                   Error="@(_parseError != null)"
                   ErrorText="@_parseError"
-                  HelperText="дд.мм.гггг, сегодня/завтра/вчера или с/з/в/пз/пв"
                   Immediate
                   Label="Дата"
                   OnAdornmentClick="OpenDatePickerAsync"

--- a/frontend/Money.Web/Components/SmartSum.razor
+++ b/frontend/Money.Web/Components/SmartSum.razor
@@ -1,16 +1,18 @@
 ﻿@if (_isNumericSumVisible)
 {
-    <MudNumericField @ref="_numericField"
-                     Adornment="Adornment.Start"
-                     AdornmentColor="Color.Tertiary"
-                     AdornmentIcon="@Icons.Material.Rounded.Calculate"
-                     AutoFocus="IsAutoFocus"
-                     @bind-Value="Sum"
-                     For="@(() => Sum)"
-                     Immediate
-                     Label="Сумма"
-                     OnAdornmentClick="ToggleSumFieldAsync"
-                     OnKeyDown="OnSumKeyDownAsync" />
+    <div @onfocusin="OnNumericFocusInAsync">
+        <MudNumericField Adornment="Adornment.Start"
+                         AdornmentColor="Color.Tertiary"
+                         AdornmentIcon="@Icons.Material.Rounded.Calculate"
+                         @bind-Value="Sum"
+                         For="@(() => Sum)"
+                         Immediate
+                         Label="Сумма"
+                         OnAdornmentClick="EnterTextModeAsync"
+                         OnKeyDown="OnSumKeyDownAsync"
+                         ReadOnly="@HasExpression"
+                         @ref="_numericField" />
+    </div>
 }
 else
 {
@@ -23,6 +25,6 @@ else
                   For="@(() => _calculationSum)"
                   Immediate
                   Label="Сумма"
-                  OnAdornmentClick="ToggleSumFieldAsync"
-                  OnBlur="ToggleSumFieldAsync" />
+                  OnAdornmentClick="ExitTextModeAsync"
+                  OnBlur="ExitTextModeAsync" />
 }

--- a/frontend/Money.Web/Components/SmartSum.razor.cs
+++ b/frontend/Money.Web/Components/SmartSum.razor.cs
@@ -29,6 +29,20 @@ public partial class SmartSum : ComponentBase
     [Inject]
     private ILogger<SmartSum> Logger { get; set; } = null!;
 
+    private bool HasExpression
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(_calculationSum))
+            {
+                return false;
+            }
+
+            var normalized = string.Concat(_calculationSum.Where(c => !char.IsWhiteSpace(c))).Replace(',', '.');
+            return !decimal.TryParse(normalized, NumberStyles.Number, CultureInfo.InvariantCulture, out _);
+        }
+    }
+
     public async Task<decimal?> GetSumAsync()
     {
         if (await TryUpdateSumAsync())
@@ -47,15 +61,23 @@ public partial class SmartSum : ComponentBase
         }
     }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!firstRender || !Sum.HasValue || _numericField == null)
+        if (!firstRender || _numericField == null)
         {
             return;
         }
 
-        _numericField.ForceRender(true);
-        StateHasChanged();
+        if (Sum.HasValue)
+        {
+            _numericField.ForceRender(true);
+            StateHasChanged();
+        }
+
+        if (IsAutoFocus)
+        {
+            await _numericField.FocusAsync();
+        }
     }
 
     private async Task<bool> TryUpdateSumAsync()
@@ -65,21 +87,19 @@ public partial class SmartSum : ComponentBase
             return true;
         }
 
-        decimal? sum = null;
-
-        if (_calculationSum != null)
+        if (string.IsNullOrWhiteSpace(_calculationSum))
         {
-            sum = await CalculateAsync();
+            return true;
+        }
 
-            if (sum == null)
-            {
-                return false;
-            }
+        var sum = await CalculateAsync();
+
+        if (sum == null)
+        {
+            return false;
         }
 
         Sum = sum;
-        _calculationSum = Sum?.ToString(CultureInfo.CurrentCulture);
-
         return true;
     }
 
@@ -89,36 +109,65 @@ public partial class SmartSum : ComponentBase
         _calculationSum = sum?.ToString(CultureInfo.CurrentCulture);
     }
 
-    private async Task ToggleSumFieldAsync()
+    private async Task EnterTextModeAsync()
     {
-        if (_isNumericSumVisible)
-        {
-            _calculationSum = Sum?.ToString(CultureInfo.CurrentCulture);
-        }
-        else if (!await TryUpdateSumAsync())
+        if (!_isNumericSumVisible)
         {
             return;
         }
 
-        _isNumericSumVisible = !_isNumericSumVisible;
+        if (!HasExpression)
+        {
+            _calculationSum = Sum?.ToString(CultureInfo.CurrentCulture);
+        }
+
+        _isNumericSumVisible = false;
         await Task.Delay(10);
         StateHasChanged();
     }
 
-    private async Task OnSumKeyDownAsync(KeyboardEventArgs args)
+    private async Task ExitTextModeAsync()
     {
-        var key = args.Key.Length == 1 ? args.Key[0] : '\0';
-
-        if (key != '\0' && ValidSpecialCharacters.Contains(key))
+        if (_isNumericSumVisible)
         {
-            await ToggleSumFieldAsync();
             return;
         }
 
-        if (key != '-')
+        if (!await TryUpdateSumAsync())
         {
-            _calculationSum += key;
+            return;
         }
+
+        _isNumericSumVisible = true;
+        await Task.Delay(10);
+        StateHasChanged();
+    }
+
+    private Task OnNumericFocusInAsync()
+    {
+        if (!_isNumericSumVisible || !HasExpression)
+        {
+            return Task.CompletedTask;
+        }
+
+        return EnterTextModeAsync();
+    }
+
+    private Task OnSumKeyDownAsync(KeyboardEventArgs args)
+    {
+        if (!_isNumericSumVisible || HasExpression)
+        {
+            return Task.CompletedTask;
+        }
+
+        var key = args.Key.Length == 1 ? args.Key[0] : '\0';
+
+        if (key == '\0' || !ValidSpecialCharacters.Contains(key))
+        {
+            return Task.CompletedTask;
+        }
+
+        return EnterTextModeAsync();
     }
 
     private async Task<decimal?> CalculateAsync()
@@ -132,7 +181,7 @@ public partial class SmartSum : ComponentBase
 
         try
         {
-            var rawSum = _calculationSum.Replace(',', '.');
+            var rawSum = string.Concat(_calculationSum.Where(c => !char.IsWhiteSpace(c))).Replace(',', '.');
             var expression = Factory.Create(rawSum, ExpressionOptions.DecimalAsDefault);
 
             var rawResult = await expression.EvaluateAsync();

--- a/frontend/Money.Web/Pages/Home.razor.cs
+++ b/frontend/Money.Web/Pages/Home.razor.cs
@@ -4,299 +4,305 @@ public partial class Home
 {
     private readonly List<VersionHistoryEntry> _versionHistory =
     [
-        new("1.3.14", new DateTime(2026, 4, 24), [
-            new VersionChange("Исправлена ошибка рендера при отмене подсказанной категории в диалоге операции.", ChangeType.BugFix),
-            new VersionChange("Чип с подсказанной категорией больше не вылезает за границы: длинное имя обрезается с троеточием, полное видно во всплывающей подсказке. Слово «Подставлено» перенесено в подсказку.", ChangeType.UiUx),
-            new VersionChange("Крестик на чипе подсказанной категории подсвечивается красным при наведении и показывает подсказку «Убрать подстановку».", ChangeType.UiUx),
-            new VersionChange("Убран вспомогательный текст под полем даты (Занимал много места).", ChangeType.UiUx),
+        new("1.3.15", new(2026, 4, 26), [
+            new("Исправлено вычисление суммы операции с пробелами внутри числа: «1+5 555,00» теперь корректно считается как 5556.", ChangeType.BugFix),
+            new("В диалоге операции кнопка «Закрыть» убрана из обхода по Tab, а «Сохранить» при фокусе с клавиатуры подсвечивается обводкой.", ChangeType.UiUx),
+            new("В поле суммы операции выражение сохраняется после вычисления: при возвращении в поле (клик, Tab или иконка-калькулятор) показывается само выражение, и его можно постепенно дополнять (например, к «1+2» дописать «+5» и получить 8). Пока выражение активно, поле числа отображает результат и не редактируется напрямую (readonly); если выражения нет, поле остаётся обычным редактируемым numeric-вводом.", ChangeType.Feature),
         ]),
 
-        new("1.3.13", new DateTime(2026, 4, 24), [
-            new VersionChange("В поле даты добавлены короткие алиасы: «с» (сегодня), «з» (завтра), «в» (вчера), «пз» (послезавтра), «пв» (позавчера) и цепочки «ппз», «ппв» и т. д.", ChangeType.Feature),
+        new("1.3.14", new(2026, 4, 24), [
+            new("Исправлена ошибка рендера при отмене подсказанной категории в диалоге операции.", ChangeType.BugFix),
+            new("Чип с подсказанной категорией больше не вылезает за границы: длинное имя обрезается с троеточием, полное видно во всплывающей подсказке. Слово «Подставлено» перенесено в подсказку.", ChangeType.UiUx),
+            new("Крестик на чипе подсказанной категории подсвечивается красным при наведении и показывает подсказку «Убрать подстановку».", ChangeType.UiUx),
+            new("Убран вспомогательный текст под полем даты (Занимал много места).", ChangeType.UiUx),
         ]),
 
-        new("1.3.12", new DateTime(2026, 4, 24), [
-            new VersionChange("Исправлено зависание на экране загрузки у пользователей с нерусской локалью браузера: приложение не могло применить культуру ru-RU из-за неполных данных ICU.", ChangeType.BugFix),
+        new("1.3.13", new(2026, 4, 24), [
+            new("В поле даты добавлены короткие алиасы: «с» (сегодня), «з» (завтра), «в» (вчера), «пз» (послезавтра), «пв» (позавчера) и цепочки «ппз», «ппв» и т. д.", ChangeType.Feature),
         ]),
 
-        new("1.3.11", new DateTime(2026, 4, 23), [
-            new VersionChange("При открытии диалога операции (добавление или редактирование) фокус автоматически ставится на поле суммы. Ранее поле при этом отображалось пустым до первого клика мимо; теперь значение видно сразу.", ChangeType.UiUx),
+        new("1.3.12", new(2026, 4, 24), [
+            new("Исправлено зависание на экране загрузки у пользователей с нерусской локалью браузера: приложение не могло применить культуру ru-RU из-за неполных данных ICU.", ChangeType.BugFix),
         ]),
 
-        new("1.3.10", new DateTime(2026, 4, 23), [
-            new VersionChange("При вводе места в операции категория теперь подсказывается автоматически: если в 5 последних операциях по этому месту была одна и та же категория, появляется чип для быстрой подстановки.", ChangeType.Feature),
+        new("1.3.11", new(2026, 4, 23), [
+            new("При открытии диалога операции (добавление или редактирование) фокус автоматически ставится на поле суммы. Ранее поле при этом отображалось пустым до первого клика мимо; теперь значение видно сразу.", ChangeType.UiUx),
         ]),
 
-        new("1.3.9", new DateTime(2026, 4, 23), [
-            new VersionChange("В настройках отображения появился выбор чередования строк операций: подсветка фона или цветная полоса слева у каждой второй строки.", ChangeType.Feature),
-            new VersionChange("Суммы в списке операций выравниваются так, что копейки стоят одна под другой. Ширина колонки и включение поведения настраиваются.", ChangeType.UiUx),
-            new VersionChange("Кнопки удаления подсвечиваются красным при наведении.", ChangeType.UiUx),
-            new VersionChange("Удалённая операция остаётся на своём месте с эффектом затухания и зачёркнутым текстом, а иконка корзины превращается в кнопку восстановления.", ChangeType.UiUx),
+        new("1.3.10", new(2026, 4, 23), [
+            new("При вводе места в операции категория теперь подсказывается автоматически: если в 5 последних операциях по этому месту была одна и та же категория, появляется чип для быстрой подстановки.", ChangeType.Feature),
         ]),
 
-        new("1.3.8", new DateTime(2026, 4, 22), [
-            new VersionChange("Убрана поддержка PWA: приложение больше не устанавливается как отдельная программа и не работает в офлайне.", ChangeType.General),
+        new("1.3.9", new(2026, 4, 23), [
+            new("В настройках отображения появился выбор чередования строк операций: подсветка фона или цветная полоса слева у каждой второй строки.", ChangeType.Feature),
+            new("Суммы в списке операций выравниваются так, что копейки стоят одна под другой. Ширина колонки и включение поведения настраиваются.", ChangeType.UiUx),
+            new("Кнопки удаления подсвечиваются красным при наведении.", ChangeType.UiUx),
+            new("Удалённая операция остаётся на своём месте с эффектом затухания и зачёркнутым текстом, а иконка корзины превращается в кнопку восстановления.", ChangeType.UiUx),
         ]),
 
-        new("1.3.7", new DateTime(2026, 4, 22), [
-            new VersionChange("Цвета осей, сетки и легенды на графиках статистики теперь сразу принимают цвета новой темы при переключении светлой и тёмной.", ChangeType.BugFix),
+        new("1.3.8", new(2026, 4, 22), [
+            new("Убрана поддержка PWA: приложение больше не устанавливается как отдельная программа и не работает в офлайне.", ChangeType.General),
         ]),
 
-        new("1.3.6", new DateTime(2026, 4, 22), [
-            new VersionChange("На экране ошибки добавлена кнопка «Повторить», а переход по меню автоматически сбрасывает состояние ошибки, так что перезагрузка страницы больше не требуется.", ChangeType.UiUx),
+        new("1.3.7", new(2026, 4, 22), [
+            new("Цвета осей, сетки и легенды на графиках статистики теперь сразу принимают цвета новой темы при переключении светлой и тёмной.", ChangeType.BugFix),
         ]),
 
-        new("1.3.5", new DateTime(2026, 4, 22), [
-            new VersionChange("Усилена безопасность аутентификации: refresh-токен теперь отзывается на сервере при выходе, параллельные запросы больше не ломают rotation refresh-токенов.", ChangeType.Improvement),
-            new VersionChange("Исправлен открытый редирект: параметр returnUrl со ссылкой на чужой сайт больше не выполняется.", ChangeType.BugFix),
-            new VersionChange("Поля текущего и нового пароля на странице профиля теперь скрывают ввод.", ChangeType.BugFix),
-            new VersionChange("На странице регистрации при ошибке входа после успешной регистрации показывается корректное сообщение.", ChangeType.BugFix),
-            new VersionChange("Исправлена утечка таймера на странице профиля при быстром переходе со страницы.", ChangeType.BugFix),
+        new("1.3.6", new(2026, 4, 22), [
+            new("На экране ошибки добавлена кнопка «Повторить», а переход по меню автоматически сбрасывает состояние ошибки, так что перезагрузка страницы больше не требуется.", ChangeType.UiUx),
         ]),
 
-        new("1.3.4", new DateTime(2026, 4, 22), [
-            new VersionChange("Новые места и держатели долгов появляются в подсказках автодополнения сразу после сохранения, без перезагрузки страницы.", ChangeType.BugFix),
-            new VersionChange("Поля «Место» и «Держатель» больше не подсвечиваются красной ошибкой «Заполни меня», пока в них вводится текст.", ChangeType.BugFix),
+        new("1.3.5", new(2026, 4, 22), [
+            new("Усилена безопасность аутентификации: refresh-токен теперь отзывается на сервере при выходе, параллельные запросы больше не ломают rotation refresh-токенов.", ChangeType.Improvement),
+            new("Исправлен открытый редирект: параметр returnUrl со ссылкой на чужой сайт больше не выполняется.", ChangeType.BugFix),
+            new("Поля текущего и нового пароля на странице профиля теперь скрывают ввод.", ChangeType.BugFix),
+            new("На странице регистрации при ошибке входа после успешной регистрации показывается корректное сообщение.", ChangeType.BugFix),
+            new("Исправлена утечка таймера на странице профиля при быстром переходе со страницы.", ChangeType.BugFix),
         ]),
 
-        new("1.3.3", new DateTime(2026, 4, 22), [
-            new VersionChange("Исправлена потеря введённой даты при клике по иконке календаря: при неверном формате поле остаётся в режиме правки и показывает ошибку. Также принимаются даты без ведущего нуля (например, 5.12.2025).", ChangeType.BugFix),
-            new VersionChange("В поле даты добавлено распознавание «позавчера», «послезавтра» и их цепочек («позапозавчера», «послепослезавтра» и т. д.).", ChangeType.Feature),
+        new("1.3.4", new(2026, 4, 22), [
+            new("Новые места и держатели долгов появляются в подсказках автодополнения сразу после сохранения, без перезагрузки страницы.", ChangeType.BugFix),
+            new("Поля «Место» и «Держатель» больше не подсвечиваются красной ошибкой «Заполни меня», пока в них вводится текст.", ChangeType.BugFix),
         ]),
 
-        new("1.3.2", new DateTime(2026, 4, 22), [
-            new VersionChange("Исправлен сброс выбранного диапазона дат в фильтре операций при уходе на другую страницу и возврате обратно.", ChangeType.BugFix),
+        new("1.3.3", new(2026, 4, 22), [
+            new("Исправлена потеря введённой даты при клике по иконке календаря: при неверном формате поле остаётся в режиме правки и показывает ошибку. Также принимаются даты без ведущего нуля (например, 5.12.2025).", ChangeType.BugFix),
+            new("В поле даты добавлено распознавание «позавчера», «послезавтра» и их цепочек («позапозавчера», «послепослезавтра» и т. д.).", ChangeType.Feature),
         ]),
 
-        new("1.3.1", new DateTime(2026, 4, 22), [
-            new VersionChange("Добавлена подсказка ранее заполненных держателей при создании долга.", ChangeType.Feature),
-            new VersionChange("Исправлено сворачивание окна оплаты долга при наведении курсора.", ChangeType.BugFix),
-            new VersionChange("Сумма платежа предзаполняется остатком долга.", ChangeType.UiUx),
+        new("1.3.2", new(2026, 4, 22), [
+            new("Исправлен сброс выбранного диапазона дат в фильтре операций при уходе на другую страницу и возврате обратно.", ChangeType.BugFix),
         ]),
 
-        new("1.3.0", new DateTime(2026, 4, 21), [
-            new VersionChange("Исправлена ошибка со сдвигом даты операций, долгов и событий на предыдущий день в часовых поясах к востоку от UTC.", ChangeType.BugFix),
-            new VersionChange("Переход на .NET 10.", ChangeType.Improvement),
+        new("1.3.1", new(2026, 4, 22), [
+            new("Добавлена подсказка ранее заполненных держателей при создании долга.", ChangeType.Feature),
+            new("Исправлено сворачивание окна оплаты долга при наведении курсора.", ChangeType.BugFix),
+            new("Сумма платежа предзаполняется остатком долга.", ChangeType.UiUx),
         ]),
 
-        new("1.2.12", new DateTime(2025, 12, 25), [
-            new VersionChange("Исправлена ошибка редактирования категории: вместо сохранения изменений создавалась новая.", ChangeType.BugFix),
+        new("1.3.0", new(2026, 4, 21), [
+            new("Исправлена ошибка со сдвигом даты операций, долгов и событий на предыдущий день в часовых поясах к востоку от UTC.", ChangeType.BugFix),
+            new("Переход на .NET 10.", ChangeType.Improvement),
         ]),
 
-        new("1.2.11", new DateTime(2025, 11, 19), [
-            new VersionChange("Выполнен переход на Chart.js для отрисовки графиков.", ChangeType.Improvement),
-            new VersionChange("Добавлена настройка использования цветов темы в графиках.", ChangeType.Feature),
-            new VersionChange("Улучшена поддержка тем оформления в столбчатых и круговых диаграммах.", ChangeType.UiUx),
+        new("1.2.12", new(2025, 12, 25), [
+            new("Исправлена ошибка редактирования категории: вместо сохранения изменений создавалась новая.", ChangeType.BugFix),
         ]),
 
-        new("1.2.10", new DateTime(2025, 11, 11), [
-            new VersionChange("Переделан компонент выбора места в операциях.", ChangeType.Improvement),
-            new VersionChange("Приоритизирован текстовый ввод в компоненте выбора даты.", ChangeType.UiUx),
-            new VersionChange("Удалена интеграция с Aspire.", ChangeType.General),
-            new VersionChange("Исправлена плавающая проблема со StaticWebAssets.", ChangeType.BugFix),
-            new VersionChange("Добавлена проверка наличия email при регистрации.", ChangeType.Improvement),
+        new("1.2.11", new(2025, 11, 19), [
+            new("Выполнен переход на Chart.js для отрисовки графиков.", ChangeType.Improvement),
+            new("Добавлена настройка использования цветов темы в графиках.", ChangeType.Feature),
+            new("Улучшена поддержка тем оформления в столбчатых и круговых диаграммах.", ChangeType.UiUx),
         ]),
 
-        new("1.2.9", new DateTime(2025, 9, 17), [
-            new VersionChange("Скорректировано выравнивание кнопок и сделан обязательным email при регистрации через внешние провайдеры.", ChangeType.UiUx),
+        new("1.2.10", new(2025, 11, 11), [
+            new("Переделан компонент выбора места в операциях.", ChangeType.Improvement),
+            new("Приоритизирован текстовый ввод в компоненте выбора даты.", ChangeType.UiUx),
+            new("Удалена интеграция с Aspire.", ChangeType.General),
+            new("Исправлена плавающая проблема со StaticWebAssets.", ChangeType.BugFix),
+            new("Добавлена проверка наличия email при регистрации.", ChangeType.Improvement),
         ]),
 
-        new("1.2.8", new DateTime(2025, 8, 20), [
-            new VersionChange("Интегрированы внешние провайдеры аутентификации: Auth и GitHub.", ChangeType.Feature),
-            new VersionChange("Добавлены кнопки входа для Auth и GitHub на странице входа.", ChangeType.UiUx),
+        new("1.2.9", new(2025, 9, 17), [
+            new("Скорректировано выравнивание кнопок и сделан обязательным email при регистрации через внешние провайдеры.", ChangeType.UiUx),
         ]),
 
-        new("1.2.7", new DateTime(2025, 7, 21), [
-            new VersionChange("Добавлена возможность выбора долгов для прощения.", ChangeType.Feature),
-            new VersionChange("Реализованы действия \"выбрать все\" и \"очистить\" для долгов.", ChangeType.Feature),
-            new VersionChange("Добавлена проверка долгов перед прощением.", ChangeType.Improvement),
-            new VersionChange("Обновлён интерфейс кнопки прощения долгов.", ChangeType.UiUx),
+        new("1.2.8", new(2025, 8, 20), [
+            new("Интегрированы внешние провайдеры аутентификации: Auth и GitHub.", ChangeType.Feature),
+            new("Добавлены кнопки входа для Auth и GitHub на странице входа.", ChangeType.UiUx),
         ]),
 
-        new("1.2.6", new DateTime(2025, 7, 21), [
-            new VersionChange("Добавлена возможность отображения оплаченных долгов.", ChangeType.Feature),
-            new VersionChange("Внесены изменения в стиль отображения карточек оплаченных долгов.", ChangeType.UiUx),
+        new("1.2.7", new(2025, 7, 21), [
+            new("Добавлена возможность выбора долгов для прощения.", ChangeType.Feature),
+            new("Реализованы действия \"выбрать все\" и \"очистить\" для долгов.", ChangeType.Feature),
+            new("Добавлена проверка долгов перед прощением.", ChangeType.Improvement),
+            new("Обновлён интерфейс кнопки прощения долгов.", ChangeType.UiUx),
         ]),
 
-        new("1.2.5", new DateTime(2025, 7, 11), [
-            new VersionChange("Добавлена настройка времени жизни токенов.", ChangeType.Feature),
-            new VersionChange("Исправлены возможные проблемы со скопами токенов.", ChangeType.BugFix),
-            new VersionChange("Исправлены возможные проблемы с обновлением состояния аутентификации.", ChangeType.BugFix),
-            new VersionChange("Выполнен рефакторинг системы аутентификации.", ChangeType.Improvement),
+        new("1.2.6", new(2025, 7, 21), [
+            new("Добавлена возможность отображения оплаченных долгов.", ChangeType.Feature),
+            new("Внесены изменения в стиль отображения карточек оплаченных долгов.", ChangeType.UiUx),
         ]),
 
-        new("1.2.4", new DateTime(2025, 7, 11), [
-            new VersionChange("Добавлен компонент SmartDatePicker для улучшения работы с датами.", ChangeType.Feature),
-            new VersionChange("Реализовано ручное переключение месяцев в датах.", ChangeType.Improvement),
+        new("1.2.5", new(2025, 7, 11), [
+            new("Добавлена настройка времени жизни токенов.", ChangeType.Feature),
+            new("Исправлены возможные проблемы со скопами токенов.", ChangeType.BugFix),
+            new("Исправлены возможные проблемы с обновлением состояния аутентификации.", ChangeType.BugFix),
+            new("Выполнен рефакторинг системы аутентификации.", ChangeType.Improvement),
         ]),
 
-        new("1.2.3", new DateTime(2025, 5, 13), [
-            new VersionChange("Исправлена ошибка создания регулярной операции не на ту дату.", ChangeType.BugFix),
-            new VersionChange("Удалены ошибочно перенесённые операции.", ChangeType.BugFix),
+        new("1.2.4", new(2025, 7, 11), [
+            new("Добавлен компонент SmartDatePicker для улучшения работы с датами.", ChangeType.Feature),
+            new("Реализовано ручное переключение месяцев в датах.", ChangeType.Improvement),
         ]),
 
-        new("1.2.2", new DateTime(2025, 5, 6), [
-            new VersionChange("Исправление ошибки добавления операций.", ChangeType.BugFix),
-            new VersionChange("Исправление ошибки редактирования удаления всех сущностей.", ChangeType.BugFix),
+        new("1.2.3", new(2025, 5, 13), [
+            new("Исправлена ошибка создания регулярной операции не на ту дату.", ChangeType.BugFix),
+            new("Удалены ошибочно перенесённые операции.", ChangeType.BugFix),
         ]),
 
-        new("1.2.1.7", new DateTime(2025, 5, 3), [
-            new VersionChange("Редизайн.", ChangeType.UiUx),
+        new("1.2.2", new(2025, 5, 6), [
+            new("Исправление ошибки добавления операций.", ChangeType.BugFix),
+            new("Исправление ошибки редактирования удаления всех сущностей.", ChangeType.BugFix),
         ]),
 
-        new("0.8.2", new DateTime(2023, 9, 30), [
-            new VersionChange("В шаблонах документов добавлена трансформация в PDF.", ChangeType.Feature),
+        new("1.2.1.7", new(2025, 5, 3), [
+            new("Редизайн.", ChangeType.UiUx),
         ]),
 
-        new("0.8.1", new DateTime(2023, 1, 12), [
-            new VersionChange("Добавлен раздел \"Шаблоны документов\".", ChangeType.Feature),
+        new("0.8.2", new(2023, 9, 30), [
+            new("В шаблонах документов добавлена трансформация в PDF.", ChangeType.Feature),
         ]),
 
-        new("0.7.3", new DateTime(2022, 7, 19), [
-            new VersionChange("Исправлена проблема с датой по умолчанию при добавлении платежей в часовом поясе отличном от часового пояса сервера.", ChangeType.BugFix),
+        new("0.8.1", new(2023, 1, 12), [
+            new("Добавлен раздел \"Шаблоны документов\".", ChangeType.Feature),
         ]),
 
-        new("0.7.2", new DateTime(2022, 7, 7), [
-            new VersionChange("В шаблоны операции добавлено поле сортировки.", ChangeType.Feature),
-            new VersionChange("Выделение суммы операции после добавления из шаблона.", ChangeType.Improvement),
+        new("0.7.3", new(2022, 7, 19), [
+            new("Исправлена проблема с датой по умолчанию при добавлении платежей в часовом поясе отличном от часового пояса сервера.", ChangeType.BugFix),
         ]),
 
-        new("0.7.1", new DateTime(2022, 4, 11), [
-            new VersionChange("Добавлены шаблоны операций.", ChangeType.Feature),
-            new VersionChange("Поиск в списке категорий теперь работает.", ChangeType.BugFix),
+        new("0.7.2", new(2022, 7, 7), [
+            new("В шаблоны операции добавлено поле сортировки.", ChangeType.Feature),
+            new("Выделение суммы операции после добавления из шаблона.", ChangeType.Improvement),
         ]),
 
-        new("0.6.6", new DateTime(2021, 7, 11), [
-            new VersionChange("В регулярные платежи добавлено \"место\".", ChangeType.Feature),
+        new("0.7.1", new(2022, 4, 11), [
+            new("Добавлены шаблоны операций.", ChangeType.Feature),
+            new("Поиск в списке категорий теперь работает.", ChangeType.BugFix),
         ]),
 
-        new("0.6.5.1", new DateTime(2021, 7, 10), [
-            new VersionChange("\"Дни без операций\" отображаются если включить опцию.", ChangeType.Feature),
+        new("0.6.6", new(2021, 7, 11), [
+            new("В регулярные платежи добавлено \"место\".", ChangeType.Feature),
         ]),
 
-        new("0.6.5", new DateTime(2021, 7, 9), [
-            new VersionChange("Исправлена ошибка null в заголовке суммарного значения по типу, при отсутствии операций с данным типом.", ChangeType.BugFix),
-            new VersionChange("Дни без операций отображаются, если они позже самой ранее операции и раньше самой последней операции в выборке.", ChangeType.Feature),
+        new("0.6.5.1", new(2021, 7, 10), [
+            new("\"Дни без операций\" отображаются если включить опцию.", ChangeType.Feature),
         ]),
 
-        new("0.6.4", new DateTime(2021, 2, 22), [
-            new VersionChange("Обновление категории для отображаемых на странице операций", ChangeType.Improvement),
+        new("0.6.5", new(2021, 7, 9), [
+            new("Исправлена ошибка null в заголовке суммарного значения по типу, при отсутствии операций с данным типом.", ChangeType.BugFix),
+            new("Дни без операций отображаются, если они позже самой ранее операции и раньше самой последней операции в выборке.", ChangeType.Feature),
         ]),
 
-        new("0.6.3.3", new DateTime(2020, 5, 6), [
-            new VersionChange("Исправлена ошибка с редактированием операции", ChangeType.BugFix),
+        new("0.6.4", new(2021, 2, 22), [
+            new("Обновление категории для отображаемых на странице операций", ChangeType.Improvement),
         ]),
 
-        new("0.6.3.2", new DateTime(2020, 4, 29), [
-            new VersionChange("Исправлены ошибка отправки почты при регистрации", ChangeType.BugFix),
-            new VersionChange("Доработка умных подсказиков для места операции", ChangeType.Improvement),
+        new("0.6.3.3", new(2020, 5, 6), [
+            new("Исправлена ошибка с редактированием операции", ChangeType.BugFix),
         ]),
 
-        new("0.6.3.1", new DateTime(2020, 4, 19), [
-            new VersionChange("Редактирование суммы операций теперь тоже поддерживает формат 3*2+2*2 (запишется 10)", ChangeType.Feature),
-            new VersionChange("В операциях добавлено поле \"Место\" для заполнения и поиска (более менее умный подсказик к нему)", ChangeType.Feature),
-            new VersionChange("Исправлен баг в выборе текущей недели(если воскресенье, показывалась следующая неделя)", ChangeType.BugFix),
+        new("0.6.3.2", new(2020, 4, 29), [
+            new("Исправлены ошибка отправки почты при регистрации", ChangeType.BugFix),
+            new("Доработка умных подсказиков для места операции", ChangeType.Improvement),
         ]),
 
-        new("0.5.9.5", new DateTime(2019, 12, 21), [
-            new VersionChange("Исправлена ошибка запуска регулярный ежемесячный задач в декабре", ChangeType.BugFix),
-            new VersionChange("Добавлена иконочка у операций созданных регулярной задачей", ChangeType.UiUx),
+        new("0.6.3.1", new(2020, 4, 19), [
+            new("Редактирование суммы операций теперь тоже поддерживает формат 3*2+2*2 (запишется 10)", ChangeType.Feature),
+            new("В операциях добавлено поле \"Место\" для заполнения и поиска (более менее умный подсказик к нему)", ChangeType.Feature),
+            new("Исправлен баг в выборе текущей недели(если воскресенье, показывалась следующая неделя)", ChangeType.BugFix),
         ]),
 
-        new("0.5.9.4", new DateTime(2019, 10, 20), [
-            new VersionChange("Диаграмки в операция учитывают начало месяца и начало недели. Чуть ифнормативнее стало", ChangeType.Improvement),
+        new("0.5.9.5", new(2019, 12, 21), [
+            new("Исправлена ошибка запуска регулярный ежемесячный задач в декабре", ChangeType.BugFix),
+            new("Добавлена иконочка у операций созданных регулярной задачей", ChangeType.UiUx),
         ]),
 
-        new("0.5.9.3", new DateTime(2019, 8, 23), [
-            new VersionChange("Поле для сортировки в категориях", ChangeType.Feature),
-            new VersionChange("Режим просмотра операций \"месяц\" \"год\" с 1 числа месяца или года соответственно", ChangeType.Feature),
+        new("0.5.9.4", new(2019, 10, 20), [
+            new("Диаграмки в операция учитывают начало месяца и начало недели. Чуть ифнормативнее стало", ChangeType.Improvement),
         ]),
 
-        new("0.5.9.2", new DateTime(2019, 7, 14), [
-            new VersionChange("График по датам улучшен", ChangeType.Improvement),
-            new VersionChange("Проблемы с отрицательной суммой в графиках исправлены", ChangeType.BugFix),
+        new("0.5.9.3", new(2019, 8, 23), [
+            new("Поле для сортировки в категориях", ChangeType.Feature),
+            new("Режим просмотра операций \"месяц\" \"год\" с 1 числа месяца или года соответственно", ChangeType.Feature),
         ]),
 
-        new("0.5.9", new DateTime(2019, 7, 13), [
-            new VersionChange("Улучшено юзабилити смены даты", ChangeType.UiUx),
-            new VersionChange("Графики статистики, юзерфрендли", ChangeType.UiUx),
+        new("0.5.9.2", new(2019, 7, 14), [
+            new("График по датам улучшен", ChangeType.Improvement),
+            new("Проблемы с отрицательной суммой в графиках исправлены", ChangeType.BugFix),
         ]),
 
-        new("0.5.5", new DateTime(2019, 6, 16), [
-            new VersionChange("Функционал: показывать оплаченные долги", ChangeType.Feature),
-            new VersionChange("Функционал: перенос долгов в расходы", ChangeType.Feature),
-            new VersionChange("Функционал: слияние держателей долга", ChangeType.Feature),
+        new("0.5.9", new(2019, 7, 13), [
+            new("Улучшено юзабилити смены даты", ChangeType.UiUx),
+            new("Графики статистики, юзерфрендли", ChangeType.UiUx),
         ]),
 
-        new("0.5.1", new DateTime(2019, 4, 9), [
-            new VersionChange("Функционал: поиск по категориям с выбором вместо текста", ChangeType.Feature),
+        new("0.5.5", new(2019, 6, 16), [
+            new("Функционал: показывать оплаченные долги", ChangeType.Feature),
+            new("Функционал: перенос долгов в расходы", ChangeType.Feature),
+            new("Функционал: слияние держателей долга", ChangeType.Feature),
         ]),
 
-        new("0.5", new DateTime(2019, 4, 8), [
-            new VersionChange("Функционал: Добавлены регулярные операции", ChangeType.Feature),
+        new("0.5.1", new(2019, 4, 9), [
+            new("Функционал: поиск по категориям с выбором вместо текста", ChangeType.Feature),
         ]),
 
-        new("0.4.1", new DateTime(2018, 7, 4), [
-            new VersionChange("Андройд: удаление операций", ChangeType.Feature),
+        new("0.5", new(2019, 4, 8), [
+            new("Функционал: Добавлены регулярные операции", ChangeType.Feature),
         ]),
 
-        new("0.4", new DateTime(2018, 6, 28), [
-            new VersionChange("Андройд: бюджетная версия", ChangeType.Feature),
+        new("0.4.1", new(2018, 7, 4), [
+            new("Андройд: удаление операций", ChangeType.Feature),
         ]),
 
-        new("0.2.1", new DateTime(2018, 4, 11), [
-            new VersionChange("Операции: теперь можно заполнять свой доход", ChangeType.Feature),
+        new("0.4", new(2018, 6, 28), [
+            new("Андройд: бюджетная версия", ChangeType.Feature),
         ]),
 
-        new("0.2", new DateTime(2018, 4, 6), [
-            new VersionChange("Юзабили: редактирование операций стало более комфортным", ChangeType.UiUx),
-            new VersionChange("Сервисная часть: измененение архитектуры приложения, могут быть ошибки", ChangeType.General),
+        new("0.2.1", new(2018, 4, 11), [
+            new("Операции: теперь можно заполнять свой доход", ChangeType.Feature),
         ]),
 
-        new("0.1.9.1", new DateTime(2018, 1, 9), [
-            new VersionChange("Юзабили: редирект на страницу логина при переходе по ссылке в запретные места", ChangeType.UiUx),
+        new("0.2", new(2018, 4, 6), [
+            new("Юзабили: редактирование операций стало более комфортным", ChangeType.UiUx),
+            new("Сервисная часть: измененение архитектуры приложения, могут быть ошибки", ChangeType.General),
         ]),
 
-        new("0.1.8.9", new DateTime(2017, 12, 26), [
-            new VersionChange("Операции: поиск по категории и комменатрию", ChangeType.Feature),
-            new VersionChange("Юзабили: в разделе авто", ChangeType.UiUx),
+        new("0.1.9.1", new(2018, 1, 9), [
+            new("Юзабили: редирект на страницу логина при переходе по ссылке в запретные места", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.8", new DateTime(2017, 10, 6), [
-            new VersionChange("Новый раздел: авто", ChangeType.Feature),
-            new VersionChange("Юзабили: везде по чуть чуть", ChangeType.UiUx),
+        new("0.1.8.9", new(2017, 12, 26), [
+            new("Операции: поиск по категории и комменатрию", ChangeType.Feature),
+            new("Юзабили: в разделе авто", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.5", new DateTime(2017, 7, 17), [
-            new VersionChange("Прикручиваем андройд: произошло измененение сервисной части, возможны перебои в работе", ChangeType.General),
+        new("0.1.8.8", new(2017, 10, 6), [
+            new("Новый раздел: авто", ChangeType.Feature),
+            new("Юзабили: везде по чуть чуть", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.4", new DateTime(2017, 7, 16), [
-            new VersionChange("Категории: изменена сортировка", ChangeType.Improvement),
-            new VersionChange("Категории: добавлен компонент для выбора цвета", ChangeType.Feature),
-            new VersionChange("Категории: немного изменено редактирование", ChangeType.UiUx),
+        new("0.1.8.5", new(2017, 7, 17), [
+            new("Прикручиваем андройд: произошло измененение сервисной части, возможны перебои в работе", ChangeType.General),
         ]),
 
-        new("0.1.8.3", new DateTime(2017, 5, 31), [
-            new VersionChange("Аккаунт: добавление почты при регистрации", ChangeType.Feature),
-            new VersionChange("Аккаунт: возможность смены пароля", ChangeType.Feature),
-            new VersionChange("Отзывы: возможность оставлять, смотреть", ChangeType.Feature),
-            new VersionChange("Чуток красоты в логине", ChangeType.UiUx),
+        new("0.1.8.4", new(2017, 7, 16), [
+            new("Категории: изменена сортировка", ChangeType.Improvement),
+            new("Категории: добавлен компонент для выбора цвета", ChangeType.Feature),
+            new("Категории: немного изменено редактирование", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.2", new DateTime(2017, 5, 30), [
-            new VersionChange("Долги: датапикеры на поля типа \"дата\"", ChangeType.UiUx),
-            new VersionChange("Операции: датапикеры на поля типа \"дата\"", ChangeType.UiUx),
-            new VersionChange("Операции: плюс небольшой график", ChangeType.Feature),
+        new("0.1.8.3", new(2017, 5, 31), [
+            new("Аккаунт: добавление почты при регистрации", ChangeType.Feature),
+            new("Аккаунт: возможность смены пароля", ChangeType.Feature),
+            new("Отзывы: возможность оставлять, смотреть", ChangeType.Feature),
+            new("Чуток красоты в логине", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.1", new DateTime(2017, 5, 27), [
-            new VersionChange("Долги: группировка по имени", ChangeType.Feature),
-            new VersionChange("Долги: удаление", ChangeType.Feature),
-            new VersionChange("Долги: редактирование", ChangeType.Feature),
+        new("0.1.8.2", new(2017, 5, 30), [
+            new("Долги: датапикеры на поля типа \"дата\"", ChangeType.UiUx),
+            new("Операции: датапикеры на поля типа \"дата\"", ChangeType.UiUx),
+            new("Операции: плюс небольшой график", ChangeType.Feature),
         ]),
 
-        new("0.1.7", new DateTime(2017, 5, 26), []),
+        new("0.1.8.1", new(2017, 5, 27), [
+            new("Долги: группировка по имени", ChangeType.Feature),
+            new("Долги: удаление", ChangeType.Feature),
+            new("Долги: редактирование", ChangeType.Feature),
+        ]),
+
+        new("0.1.7", new(2017, 5, 26), []),
     ];
 
     private bool _historyVisible;
@@ -318,7 +324,7 @@ public partial class Home
             0 => Color.Default,
             1 => Color.Info,
             2 or 3 => Color.Primary,
-            var _ => Color.Secondary,
+            _ => Color.Secondary,
         };
     }
 
@@ -328,13 +334,13 @@ public partial class Home
         {
             0 => Icons.Material.Rounded.Circle,
             1 => Icons.Material.Rounded.FiberManualRecord,
-            var _ => Icons.Material.Rounded.RadioButtonChecked,
+            _ => Icons.Material.Rounded.RadioButtonChecked,
         };
     }
 
     private Color GetVersionChipColor(VersionHistoryEntry entry)
     {
-        string[] versionParts = entry.Version.Split('.');
+        var versionParts = entry.Version.Split('.');
 
         if (versionParts.Length < 2)
         {
@@ -363,7 +369,7 @@ public partial class Home
             ChangeType.Improvement => Icons.Material.Rounded.TrendingUp,
             ChangeType.UiUx => Icons.Material.Rounded.Palette,
             ChangeType.General => Icons.Material.Rounded.Settings,
-            var _ => Icons.Material.Rounded.Circle,
+            _ => Icons.Material.Rounded.Circle,
         };
     }
 
@@ -376,7 +382,7 @@ public partial class Home
             ChangeType.Improvement => Color.Info,
             ChangeType.UiUx => Color.Warning,
             ChangeType.General => Color.Default,
-            var _ => Color.Default,
+            _ => Color.Default,
         };
     }
 }

--- a/frontend/Money.Web/Pages/Home.razor.cs
+++ b/frontend/Money.Web/Pages/Home.razor.cs
@@ -4,292 +4,299 @@ public partial class Home
 {
     private readonly List<VersionHistoryEntry> _versionHistory =
     [
-        new("1.3.13", new(2026, 4, 24), [
-            new("В поле даты добавлены короткие алиасы: «с» (сегодня), «з» (завтра), «в» (вчера), «пз» (послезавтра), «пв» (позавчера) и цепочки «ппз», «ппв» и т. д.", ChangeType.Feature),
+        new("1.3.14", new DateTime(2026, 4, 24), [
+            new VersionChange("Исправлена ошибка рендера при отмене подсказанной категории в диалоге операции.", ChangeType.BugFix),
+            new VersionChange("Чип с подсказанной категорией больше не вылезает за границы: длинное имя обрезается с троеточием, полное видно во всплывающей подсказке. Слово «Подставлено» перенесено в подсказку.", ChangeType.UiUx),
+            new VersionChange("Крестик на чипе подсказанной категории подсвечивается красным при наведении и показывает подсказку «Убрать подстановку».", ChangeType.UiUx),
+            new VersionChange("Убран вспомогательный текст под полем даты (Занимал много места).", ChangeType.UiUx),
         ]),
 
-        new("1.3.12", new(2026, 4, 24), [
-            new("Исправлено зависание на экране загрузки у пользователей с нерусской локалью браузера: приложение не могло применить культуру ru-RU из-за неполных данных ICU.", ChangeType.BugFix),
+        new("1.3.13", new DateTime(2026, 4, 24), [
+            new VersionChange("В поле даты добавлены короткие алиасы: «с» (сегодня), «з» (завтра), «в» (вчера), «пз» (послезавтра), «пв» (позавчера) и цепочки «ппз», «ппв» и т. д.", ChangeType.Feature),
         ]),
 
-        new("1.3.11", new(2026, 4, 23), [
-            new("При открытии диалога операции (добавление или редактирование) фокус автоматически ставится на поле суммы. Ранее поле при этом отображалось пустым до первого клика мимо; теперь значение видно сразу.", ChangeType.UiUx),
+        new("1.3.12", new DateTime(2026, 4, 24), [
+            new VersionChange("Исправлено зависание на экране загрузки у пользователей с нерусской локалью браузера: приложение не могло применить культуру ru-RU из-за неполных данных ICU.", ChangeType.BugFix),
         ]),
 
-        new("1.3.10", new(2026, 4, 23), [
-            new("При вводе места в операции категория теперь подсказывается автоматически: если в 5 последних операциях по этому месту была одна и та же категория, появляется чип для быстрой подстановки.", ChangeType.Feature),
+        new("1.3.11", new DateTime(2026, 4, 23), [
+            new VersionChange("При открытии диалога операции (добавление или редактирование) фокус автоматически ставится на поле суммы. Ранее поле при этом отображалось пустым до первого клика мимо; теперь значение видно сразу.", ChangeType.UiUx),
         ]),
 
-        new("1.3.9", new(2026, 4, 23), [
-            new("В настройках отображения появился выбор чередования строк операций: подсветка фона или цветная полоса слева у каждой второй строки.", ChangeType.Feature),
-            new("Суммы в списке операций выравниваются так, что копейки стоят одна под другой. Ширина колонки и включение поведения настраиваются.", ChangeType.UiUx),
-            new("Кнопки удаления подсвечиваются красным при наведении.", ChangeType.UiUx),
-            new("Удалённая операция остаётся на своём месте с эффектом затухания и зачёркнутым текстом, а иконка корзины превращается в кнопку восстановления.", ChangeType.UiUx),
+        new("1.3.10", new DateTime(2026, 4, 23), [
+            new VersionChange("При вводе места в операции категория теперь подсказывается автоматически: если в 5 последних операциях по этому месту была одна и та же категория, появляется чип для быстрой подстановки.", ChangeType.Feature),
         ]),
 
-        new("1.3.8", new(2026, 4, 22), [
-            new("Убрана поддержка PWA: приложение больше не устанавливается как отдельная программа и не работает в офлайне.", ChangeType.General),
+        new("1.3.9", new DateTime(2026, 4, 23), [
+            new VersionChange("В настройках отображения появился выбор чередования строк операций: подсветка фона или цветная полоса слева у каждой второй строки.", ChangeType.Feature),
+            new VersionChange("Суммы в списке операций выравниваются так, что копейки стоят одна под другой. Ширина колонки и включение поведения настраиваются.", ChangeType.UiUx),
+            new VersionChange("Кнопки удаления подсвечиваются красным при наведении.", ChangeType.UiUx),
+            new VersionChange("Удалённая операция остаётся на своём месте с эффектом затухания и зачёркнутым текстом, а иконка корзины превращается в кнопку восстановления.", ChangeType.UiUx),
         ]),
 
-        new("1.3.7", new(2026, 4, 22), [
-            new("Цвета осей, сетки и легенды на графиках статистики теперь сразу принимают цвета новой темы при переключении светлой и тёмной.", ChangeType.BugFix),
+        new("1.3.8", new DateTime(2026, 4, 22), [
+            new VersionChange("Убрана поддержка PWA: приложение больше не устанавливается как отдельная программа и не работает в офлайне.", ChangeType.General),
         ]),
 
-        new("1.3.6", new(2026, 4, 22), [
-            new("На экране ошибки добавлена кнопка «Повторить», а переход по меню автоматически сбрасывает состояние ошибки, так что перезагрузка страницы больше не требуется.", ChangeType.UiUx),
+        new("1.3.7", new DateTime(2026, 4, 22), [
+            new VersionChange("Цвета осей, сетки и легенды на графиках статистики теперь сразу принимают цвета новой темы при переключении светлой и тёмной.", ChangeType.BugFix),
         ]),
 
-        new("1.3.5", new(2026, 4, 22), [
-            new("Усилена безопасность аутентификации: refresh-токен теперь отзывается на сервере при выходе, параллельные запросы больше не ломают rotation refresh-токенов.", ChangeType.Improvement),
-            new("Исправлен открытый редирект: параметр returnUrl со ссылкой на чужой сайт больше не выполняется.", ChangeType.BugFix),
-            new("Поля текущего и нового пароля на странице профиля теперь скрывают ввод.", ChangeType.BugFix),
-            new("На странице регистрации при ошибке входа после успешной регистрации показывается корректное сообщение.", ChangeType.BugFix),
-            new("Исправлена утечка таймера на странице профиля при быстром переходе со страницы.", ChangeType.BugFix),
+        new("1.3.6", new DateTime(2026, 4, 22), [
+            new VersionChange("На экране ошибки добавлена кнопка «Повторить», а переход по меню автоматически сбрасывает состояние ошибки, так что перезагрузка страницы больше не требуется.", ChangeType.UiUx),
         ]),
 
-        new("1.3.4", new(2026, 4, 22), [
-            new("Новые места и держатели долгов появляются в подсказках автодополнения сразу после сохранения, без перезагрузки страницы.", ChangeType.BugFix),
-            new("Поля «Место» и «Держатель» больше не подсвечиваются красной ошибкой «Заполни меня», пока в них вводится текст.", ChangeType.BugFix),
+        new("1.3.5", new DateTime(2026, 4, 22), [
+            new VersionChange("Усилена безопасность аутентификации: refresh-токен теперь отзывается на сервере при выходе, параллельные запросы больше не ломают rotation refresh-токенов.", ChangeType.Improvement),
+            new VersionChange("Исправлен открытый редирект: параметр returnUrl со ссылкой на чужой сайт больше не выполняется.", ChangeType.BugFix),
+            new VersionChange("Поля текущего и нового пароля на странице профиля теперь скрывают ввод.", ChangeType.BugFix),
+            new VersionChange("На странице регистрации при ошибке входа после успешной регистрации показывается корректное сообщение.", ChangeType.BugFix),
+            new VersionChange("Исправлена утечка таймера на странице профиля при быстром переходе со страницы.", ChangeType.BugFix),
         ]),
 
-        new("1.3.3", new(2026, 4, 22), [
-            new("Исправлена потеря введённой даты при клике по иконке календаря: при неверном формате поле остаётся в режиме правки и показывает ошибку. Также принимаются даты без ведущего нуля (например, 5.12.2025).", ChangeType.BugFix),
-            new("В поле даты добавлено распознавание «позавчера», «послезавтра» и их цепочек («позапозавчера», «послепослезавтра» и т. д.).", ChangeType.Feature),
+        new("1.3.4", new DateTime(2026, 4, 22), [
+            new VersionChange("Новые места и держатели долгов появляются в подсказках автодополнения сразу после сохранения, без перезагрузки страницы.", ChangeType.BugFix),
+            new VersionChange("Поля «Место» и «Держатель» больше не подсвечиваются красной ошибкой «Заполни меня», пока в них вводится текст.", ChangeType.BugFix),
         ]),
 
-        new("1.3.2", new(2026, 4, 22), [
-            new("Исправлен сброс выбранного диапазона дат в фильтре операций при уходе на другую страницу и возврате обратно.", ChangeType.BugFix),
+        new("1.3.3", new DateTime(2026, 4, 22), [
+            new VersionChange("Исправлена потеря введённой даты при клике по иконке календаря: при неверном формате поле остаётся в режиме правки и показывает ошибку. Также принимаются даты без ведущего нуля (например, 5.12.2025).", ChangeType.BugFix),
+            new VersionChange("В поле даты добавлено распознавание «позавчера», «послезавтра» и их цепочек («позапозавчера», «послепослезавтра» и т. д.).", ChangeType.Feature),
         ]),
 
-        new("1.3.1", new(2026, 4, 22), [
-            new("Добавлена подсказка ранее заполненных держателей при создании долга.", ChangeType.Feature),
-            new("Исправлено сворачивание окна оплаты долга при наведении курсора.", ChangeType.BugFix),
-            new("Сумма платежа предзаполняется остатком долга.", ChangeType.UiUx),
+        new("1.3.2", new DateTime(2026, 4, 22), [
+            new VersionChange("Исправлен сброс выбранного диапазона дат в фильтре операций при уходе на другую страницу и возврате обратно.", ChangeType.BugFix),
         ]),
 
-        new("1.3.0", new(2026, 4, 21), [
-            new("Исправлена ошибка со сдвигом даты операций, долгов и событий на предыдущий день в часовых поясах к востоку от UTC.", ChangeType.BugFix),
-            new("Переход на .NET 10.", ChangeType.Improvement),
+        new("1.3.1", new DateTime(2026, 4, 22), [
+            new VersionChange("Добавлена подсказка ранее заполненных держателей при создании долга.", ChangeType.Feature),
+            new VersionChange("Исправлено сворачивание окна оплаты долга при наведении курсора.", ChangeType.BugFix),
+            new VersionChange("Сумма платежа предзаполняется остатком долга.", ChangeType.UiUx),
         ]),
 
-        new("1.2.12", new(2025, 12, 25), [
-            new("Исправлена ошибка редактирования категории: вместо сохранения изменений создавалась новая.", ChangeType.BugFix),
+        new("1.3.0", new DateTime(2026, 4, 21), [
+            new VersionChange("Исправлена ошибка со сдвигом даты операций, долгов и событий на предыдущий день в часовых поясах к востоку от UTC.", ChangeType.BugFix),
+            new VersionChange("Переход на .NET 10.", ChangeType.Improvement),
         ]),
 
-        new("1.2.11", new(2025, 11, 19), [
-            new("Выполнен переход на Chart.js для отрисовки графиков.", ChangeType.Improvement),
-            new("Добавлена настройка использования цветов темы в графиках.", ChangeType.Feature),
-            new("Улучшена поддержка тем оформления в столбчатых и круговых диаграммах.", ChangeType.UiUx),
+        new("1.2.12", new DateTime(2025, 12, 25), [
+            new VersionChange("Исправлена ошибка редактирования категории: вместо сохранения изменений создавалась новая.", ChangeType.BugFix),
         ]),
 
-        new("1.2.10", new(2025, 11, 11), [
-            new("Переделан компонент выбора места в операциях.", ChangeType.Improvement),
-            new("Приоритизирован текстовый ввод в компоненте выбора даты.", ChangeType.UiUx),
-            new("Удалена интеграция с Aspire.", ChangeType.General),
-            new("Исправлена плавающая проблема со StaticWebAssets.", ChangeType.BugFix),
-            new("Добавлена проверка наличия email при регистрации.", ChangeType.Improvement),
+        new("1.2.11", new DateTime(2025, 11, 19), [
+            new VersionChange("Выполнен переход на Chart.js для отрисовки графиков.", ChangeType.Improvement),
+            new VersionChange("Добавлена настройка использования цветов темы в графиках.", ChangeType.Feature),
+            new VersionChange("Улучшена поддержка тем оформления в столбчатых и круговых диаграммах.", ChangeType.UiUx),
         ]),
 
-        new("1.2.9", new(2025, 9, 17), [
-            new("Скорректировано выравнивание кнопок и сделан обязательным email при регистрации через внешние провайдеры.", ChangeType.UiUx),
+        new("1.2.10", new DateTime(2025, 11, 11), [
+            new VersionChange("Переделан компонент выбора места в операциях.", ChangeType.Improvement),
+            new VersionChange("Приоритизирован текстовый ввод в компоненте выбора даты.", ChangeType.UiUx),
+            new VersionChange("Удалена интеграция с Aspire.", ChangeType.General),
+            new VersionChange("Исправлена плавающая проблема со StaticWebAssets.", ChangeType.BugFix),
+            new VersionChange("Добавлена проверка наличия email при регистрации.", ChangeType.Improvement),
         ]),
 
-        new("1.2.8", new(2025, 8, 20), [
-            new("Интегрированы внешние провайдеры аутентификации: Auth и GitHub.", ChangeType.Feature),
-            new("Добавлены кнопки входа для Auth и GitHub на странице входа.", ChangeType.UiUx),
+        new("1.2.9", new DateTime(2025, 9, 17), [
+            new VersionChange("Скорректировано выравнивание кнопок и сделан обязательным email при регистрации через внешние провайдеры.", ChangeType.UiUx),
         ]),
 
-        new("1.2.7", new(2025, 7, 21), [
-            new("Добавлена возможность выбора долгов для прощения.", ChangeType.Feature),
-            new("Реализованы действия \"выбрать все\" и \"очистить\" для долгов.", ChangeType.Feature),
-            new("Добавлена проверка долгов перед прощением.", ChangeType.Improvement),
-            new("Обновлён интерфейс кнопки прощения долгов.", ChangeType.UiUx),
+        new("1.2.8", new DateTime(2025, 8, 20), [
+            new VersionChange("Интегрированы внешние провайдеры аутентификации: Auth и GitHub.", ChangeType.Feature),
+            new VersionChange("Добавлены кнопки входа для Auth и GitHub на странице входа.", ChangeType.UiUx),
         ]),
 
-        new("1.2.6", new(2025, 7, 21), [
-            new("Добавлена возможность отображения оплаченных долгов.", ChangeType.Feature),
-            new("Внесены изменения в стиль отображения карточек оплаченных долгов.", ChangeType.UiUx),
+        new("1.2.7", new DateTime(2025, 7, 21), [
+            new VersionChange("Добавлена возможность выбора долгов для прощения.", ChangeType.Feature),
+            new VersionChange("Реализованы действия \"выбрать все\" и \"очистить\" для долгов.", ChangeType.Feature),
+            new VersionChange("Добавлена проверка долгов перед прощением.", ChangeType.Improvement),
+            new VersionChange("Обновлён интерфейс кнопки прощения долгов.", ChangeType.UiUx),
         ]),
 
-        new("1.2.5", new(2025, 7, 11), [
-            new("Добавлена настройка времени жизни токенов.", ChangeType.Feature),
-            new("Исправлены возможные проблемы со скопами токенов.", ChangeType.BugFix),
-            new("Исправлены возможные проблемы с обновлением состояния аутентификации.", ChangeType.BugFix),
-            new("Выполнен рефакторинг системы аутентификации.", ChangeType.Improvement),
+        new("1.2.6", new DateTime(2025, 7, 21), [
+            new VersionChange("Добавлена возможность отображения оплаченных долгов.", ChangeType.Feature),
+            new VersionChange("Внесены изменения в стиль отображения карточек оплаченных долгов.", ChangeType.UiUx),
         ]),
 
-        new("1.2.4", new(2025, 7, 11), [
-            new("Добавлен компонент SmartDatePicker для улучшения работы с датами.", ChangeType.Feature),
-            new("Реализовано ручное переключение месяцев в датах.", ChangeType.Improvement),
+        new("1.2.5", new DateTime(2025, 7, 11), [
+            new VersionChange("Добавлена настройка времени жизни токенов.", ChangeType.Feature),
+            new VersionChange("Исправлены возможные проблемы со скопами токенов.", ChangeType.BugFix),
+            new VersionChange("Исправлены возможные проблемы с обновлением состояния аутентификации.", ChangeType.BugFix),
+            new VersionChange("Выполнен рефакторинг системы аутентификации.", ChangeType.Improvement),
         ]),
 
-        new("1.2.3", new(2025, 5, 13), [
-            new("Исправлена ошибка создания регулярной операции не на ту дату.", ChangeType.BugFix),
-            new("Удалены ошибочно перенесённые операции.", ChangeType.BugFix),
+        new("1.2.4", new DateTime(2025, 7, 11), [
+            new VersionChange("Добавлен компонент SmartDatePicker для улучшения работы с датами.", ChangeType.Feature),
+            new VersionChange("Реализовано ручное переключение месяцев в датах.", ChangeType.Improvement),
         ]),
 
-        new("1.2.2", new(2025, 5, 6), [
-            new("Исправление ошибки добавления операций.", ChangeType.BugFix),
-            new("Исправление ошибки редактирования удаления всех сущностей.", ChangeType.BugFix),
+        new("1.2.3", new DateTime(2025, 5, 13), [
+            new VersionChange("Исправлена ошибка создания регулярной операции не на ту дату.", ChangeType.BugFix),
+            new VersionChange("Удалены ошибочно перенесённые операции.", ChangeType.BugFix),
         ]),
 
-        new("1.2.1.7", new(2025, 5, 3), [
-            new("Редизайн.", ChangeType.UiUx),
+        new("1.2.2", new DateTime(2025, 5, 6), [
+            new VersionChange("Исправление ошибки добавления операций.", ChangeType.BugFix),
+            new VersionChange("Исправление ошибки редактирования удаления всех сущностей.", ChangeType.BugFix),
         ]),
 
-        new("0.8.2", new(2023, 9, 30), [
-            new("В шаблонах документов добавлена трансформация в PDF.", ChangeType.Feature),
+        new("1.2.1.7", new DateTime(2025, 5, 3), [
+            new VersionChange("Редизайн.", ChangeType.UiUx),
         ]),
 
-        new("0.8.1", new(2023, 1, 12), [
-            new("Добавлен раздел \"Шаблоны документов\".", ChangeType.Feature),
+        new("0.8.2", new DateTime(2023, 9, 30), [
+            new VersionChange("В шаблонах документов добавлена трансформация в PDF.", ChangeType.Feature),
         ]),
 
-        new("0.7.3", new(2022, 7, 19), [
-            new("Исправлена проблема с датой по умолчанию при добавлении платежей в часовом поясе отличном от часового пояса сервера.", ChangeType.BugFix),
+        new("0.8.1", new DateTime(2023, 1, 12), [
+            new VersionChange("Добавлен раздел \"Шаблоны документов\".", ChangeType.Feature),
         ]),
 
-        new("0.7.2", new(2022, 7, 7), [
-            new("В шаблоны операции добавлено поле сортировки.", ChangeType.Feature),
-            new("Выделение суммы операции после добавления из шаблона.", ChangeType.Improvement),
+        new("0.7.3", new DateTime(2022, 7, 19), [
+            new VersionChange("Исправлена проблема с датой по умолчанию при добавлении платежей в часовом поясе отличном от часового пояса сервера.", ChangeType.BugFix),
         ]),
 
-        new("0.7.1", new(2022, 4, 11), [
-            new("Добавлены шаблоны операций.", ChangeType.Feature),
-            new("Поиск в списке категорий теперь работает.", ChangeType.BugFix),
+        new("0.7.2", new DateTime(2022, 7, 7), [
+            new VersionChange("В шаблоны операции добавлено поле сортировки.", ChangeType.Feature),
+            new VersionChange("Выделение суммы операции после добавления из шаблона.", ChangeType.Improvement),
         ]),
 
-        new("0.6.6", new(2021, 7, 11), [
-            new("В регулярные платежи добавлено \"место\".", ChangeType.Feature),
+        new("0.7.1", new DateTime(2022, 4, 11), [
+            new VersionChange("Добавлены шаблоны операций.", ChangeType.Feature),
+            new VersionChange("Поиск в списке категорий теперь работает.", ChangeType.BugFix),
         ]),
 
-        new("0.6.5.1", new(2021, 7, 10), [
-            new("\"Дни без операций\" отображаются если включить опцию.", ChangeType.Feature),
+        new("0.6.6", new DateTime(2021, 7, 11), [
+            new VersionChange("В регулярные платежи добавлено \"место\".", ChangeType.Feature),
         ]),
 
-        new("0.6.5", new(2021, 7, 9), [
-            new("Исправлена ошибка null в заголовке суммарного значения по типу, при отсутствии операций с данным типом.", ChangeType.BugFix),
-            new("Дни без операций отображаются, если они позже самой ранее операции и раньше самой последней операции в выборке.", ChangeType.Feature),
+        new("0.6.5.1", new DateTime(2021, 7, 10), [
+            new VersionChange("\"Дни без операций\" отображаются если включить опцию.", ChangeType.Feature),
         ]),
 
-        new("0.6.4", new(2021, 2, 22), [
-            new("Обновление категории для отображаемых на странице операций", ChangeType.Improvement),
+        new("0.6.5", new DateTime(2021, 7, 9), [
+            new VersionChange("Исправлена ошибка null в заголовке суммарного значения по типу, при отсутствии операций с данным типом.", ChangeType.BugFix),
+            new VersionChange("Дни без операций отображаются, если они позже самой ранее операции и раньше самой последней операции в выборке.", ChangeType.Feature),
         ]),
 
-        new("0.6.3.3", new(2020, 5, 6), [
-            new("Исправлена ошибка с редактированием операции", ChangeType.BugFix),
+        new("0.6.4", new DateTime(2021, 2, 22), [
+            new VersionChange("Обновление категории для отображаемых на странице операций", ChangeType.Improvement),
         ]),
 
-        new("0.6.3.2", new(2020, 4, 29), [
-            new("Исправлены ошибка отправки почты при регистрации", ChangeType.BugFix),
-            new("Доработка умных подсказиков для места операции", ChangeType.Improvement),
+        new("0.6.3.3", new DateTime(2020, 5, 6), [
+            new VersionChange("Исправлена ошибка с редактированием операции", ChangeType.BugFix),
         ]),
 
-        new("0.6.3.1", new(2020, 4, 19), [
-            new("Редактирование суммы операций теперь тоже поддерживает формат 3*2+2*2 (запишется 10)", ChangeType.Feature),
-            new("В операциях добавлено поле \"Место\" для заполнения и поиска (более менее умный подсказик к нему)", ChangeType.Feature),
-            new("Исправлен баг в выборе текущей недели(если воскресенье, показывалась следующая неделя)", ChangeType.BugFix),
+        new("0.6.3.2", new DateTime(2020, 4, 29), [
+            new VersionChange("Исправлены ошибка отправки почты при регистрации", ChangeType.BugFix),
+            new VersionChange("Доработка умных подсказиков для места операции", ChangeType.Improvement),
         ]),
 
-        new("0.5.9.5", new(2019, 12, 21), [
-            new("Исправлена ошибка запуска регулярный ежемесячный задач в декабре", ChangeType.BugFix),
-            new("Добавлена иконочка у операций созданных регулярной задачей", ChangeType.UiUx),
+        new("0.6.3.1", new DateTime(2020, 4, 19), [
+            new VersionChange("Редактирование суммы операций теперь тоже поддерживает формат 3*2+2*2 (запишется 10)", ChangeType.Feature),
+            new VersionChange("В операциях добавлено поле \"Место\" для заполнения и поиска (более менее умный подсказик к нему)", ChangeType.Feature),
+            new VersionChange("Исправлен баг в выборе текущей недели(если воскресенье, показывалась следующая неделя)", ChangeType.BugFix),
         ]),
 
-        new("0.5.9.4", new(2019, 10, 20), [
-            new("Диаграмки в операция учитывают начало месяца и начало недели. Чуть ифнормативнее стало", ChangeType.Improvement),
+        new("0.5.9.5", new DateTime(2019, 12, 21), [
+            new VersionChange("Исправлена ошибка запуска регулярный ежемесячный задач в декабре", ChangeType.BugFix),
+            new VersionChange("Добавлена иконочка у операций созданных регулярной задачей", ChangeType.UiUx),
         ]),
 
-        new("0.5.9.3", new(2019, 8, 23), [
-            new("Поле для сортировки в категориях", ChangeType.Feature),
-            new("Режим просмотра операций \"месяц\" \"год\" с 1 числа месяца или года соответственно", ChangeType.Feature),
+        new("0.5.9.4", new DateTime(2019, 10, 20), [
+            new VersionChange("Диаграмки в операция учитывают начало месяца и начало недели. Чуть ифнормативнее стало", ChangeType.Improvement),
         ]),
 
-        new("0.5.9.2", new(2019, 7, 14), [
-            new("График по датам улучшен", ChangeType.Improvement),
-            new("Проблемы с отрицательной суммой в графиках исправлены", ChangeType.BugFix),
+        new("0.5.9.3", new DateTime(2019, 8, 23), [
+            new VersionChange("Поле для сортировки в категориях", ChangeType.Feature),
+            new VersionChange("Режим просмотра операций \"месяц\" \"год\" с 1 числа месяца или года соответственно", ChangeType.Feature),
         ]),
 
-        new("0.5.9", new(2019, 7, 13), [
-            new("Улучшено юзабилити смены даты", ChangeType.UiUx),
-            new("Графики статистики, юзерфрендли", ChangeType.UiUx),
+        new("0.5.9.2", new DateTime(2019, 7, 14), [
+            new VersionChange("График по датам улучшен", ChangeType.Improvement),
+            new VersionChange("Проблемы с отрицательной суммой в графиках исправлены", ChangeType.BugFix),
         ]),
 
-        new("0.5.5", new(2019, 6, 16), [
-            new("Функционал: показывать оплаченные долги", ChangeType.Feature),
-            new("Функционал: перенос долгов в расходы", ChangeType.Feature),
-            new("Функционал: слияние держателей долга", ChangeType.Feature),
+        new("0.5.9", new DateTime(2019, 7, 13), [
+            new VersionChange("Улучшено юзабилити смены даты", ChangeType.UiUx),
+            new VersionChange("Графики статистики, юзерфрендли", ChangeType.UiUx),
         ]),
 
-        new("0.5.1", new(2019, 4, 9), [
-            new("Функционал: поиск по категориям с выбором вместо текста", ChangeType.Feature),
+        new("0.5.5", new DateTime(2019, 6, 16), [
+            new VersionChange("Функционал: показывать оплаченные долги", ChangeType.Feature),
+            new VersionChange("Функционал: перенос долгов в расходы", ChangeType.Feature),
+            new VersionChange("Функционал: слияние держателей долга", ChangeType.Feature),
         ]),
 
-        new("0.5", new(2019, 4, 8), [
-            new("Функционал: Добавлены регулярные операции", ChangeType.Feature),
+        new("0.5.1", new DateTime(2019, 4, 9), [
+            new VersionChange("Функционал: поиск по категориям с выбором вместо текста", ChangeType.Feature),
         ]),
 
-        new("0.4.1", new(2018, 7, 4), [
-            new("Андройд: удаление операций", ChangeType.Feature),
+        new("0.5", new DateTime(2019, 4, 8), [
+            new VersionChange("Функционал: Добавлены регулярные операции", ChangeType.Feature),
         ]),
 
-        new("0.4", new(2018, 6, 28), [
-            new("Андройд: бюджетная версия", ChangeType.Feature),
+        new("0.4.1", new DateTime(2018, 7, 4), [
+            new VersionChange("Андройд: удаление операций", ChangeType.Feature),
         ]),
 
-        new("0.2.1", new(2018, 4, 11), [
-            new("Операции: теперь можно заполнять свой доход", ChangeType.Feature),
+        new("0.4", new DateTime(2018, 6, 28), [
+            new VersionChange("Андройд: бюджетная версия", ChangeType.Feature),
         ]),
 
-        new("0.2", new(2018, 4, 6), [
-            new("Юзабили: редактирование операций стало более комфортным", ChangeType.UiUx),
-            new("Сервисная часть: измененение архитектуры приложения, могут быть ошибки", ChangeType.General),
+        new("0.2.1", new DateTime(2018, 4, 11), [
+            new VersionChange("Операции: теперь можно заполнять свой доход", ChangeType.Feature),
         ]),
 
-        new("0.1.9.1", new(2018, 1, 9), [
-            new("Юзабили: редирект на страницу логина при переходе по ссылке в запретные места", ChangeType.UiUx),
+        new("0.2", new DateTime(2018, 4, 6), [
+            new VersionChange("Юзабили: редактирование операций стало более комфортным", ChangeType.UiUx),
+            new VersionChange("Сервисная часть: измененение архитектуры приложения, могут быть ошибки", ChangeType.General),
         ]),
 
-        new("0.1.8.9", new(2017, 12, 26), [
-            new("Операции: поиск по категории и комменатрию", ChangeType.Feature),
-            new("Юзабили: в разделе авто", ChangeType.UiUx),
+        new("0.1.9.1", new DateTime(2018, 1, 9), [
+            new VersionChange("Юзабили: редирект на страницу логина при переходе по ссылке в запретные места", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.8", new(2017, 10, 6), [
-            new("Новый раздел: авто", ChangeType.Feature),
-            new("Юзабили: везде по чуть чуть", ChangeType.UiUx),
+        new("0.1.8.9", new DateTime(2017, 12, 26), [
+            new VersionChange("Операции: поиск по категории и комменатрию", ChangeType.Feature),
+            new VersionChange("Юзабили: в разделе авто", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.5", new(2017, 7, 17), [
-            new("Прикручиваем андройд: произошло измененение сервисной части, возможны перебои в работе", ChangeType.General),
+        new("0.1.8.8", new DateTime(2017, 10, 6), [
+            new VersionChange("Новый раздел: авто", ChangeType.Feature),
+            new VersionChange("Юзабили: везде по чуть чуть", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.4", new(2017, 7, 16), [
-            new("Категории: изменена сортировка", ChangeType.Improvement),
-            new("Категории: добавлен компонент для выбора цвета", ChangeType.Feature),
-            new("Категории: немного изменено редактирование", ChangeType.UiUx),
+        new("0.1.8.5", new DateTime(2017, 7, 17), [
+            new VersionChange("Прикручиваем андройд: произошло измененение сервисной части, возможны перебои в работе", ChangeType.General),
         ]),
 
-        new("0.1.8.3", new(2017, 5, 31), [
-            new("Аккаунт: добавление почты при регистрации", ChangeType.Feature),
-            new("Аккаунт: возможность смены пароля", ChangeType.Feature),
-            new("Отзывы: возможность оставлять, смотреть", ChangeType.Feature),
-            new("Чуток красоты в логине", ChangeType.UiUx),
+        new("0.1.8.4", new DateTime(2017, 7, 16), [
+            new VersionChange("Категории: изменена сортировка", ChangeType.Improvement),
+            new VersionChange("Категории: добавлен компонент для выбора цвета", ChangeType.Feature),
+            new VersionChange("Категории: немного изменено редактирование", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.2", new(2017, 5, 30), [
-            new("Долги: датапикеры на поля типа \"дата\"", ChangeType.UiUx),
-            new("Операции: датапикеры на поля типа \"дата\"", ChangeType.UiUx),
-            new("Операции: плюс небольшой график", ChangeType.Feature),
+        new("0.1.8.3", new DateTime(2017, 5, 31), [
+            new VersionChange("Аккаунт: добавление почты при регистрации", ChangeType.Feature),
+            new VersionChange("Аккаунт: возможность смены пароля", ChangeType.Feature),
+            new VersionChange("Отзывы: возможность оставлять, смотреть", ChangeType.Feature),
+            new VersionChange("Чуток красоты в логине", ChangeType.UiUx),
         ]),
 
-        new("0.1.8.1", new(2017, 5, 27), [
-            new("Долги: группировка по имени", ChangeType.Feature),
-            new("Долги: удаление", ChangeType.Feature),
-            new("Долги: редактирование", ChangeType.Feature),
+        new("0.1.8.2", new DateTime(2017, 5, 30), [
+            new VersionChange("Долги: датапикеры на поля типа \"дата\"", ChangeType.UiUx),
+            new VersionChange("Операции: датапикеры на поля типа \"дата\"", ChangeType.UiUx),
+            new VersionChange("Операции: плюс небольшой график", ChangeType.Feature),
         ]),
 
-        new("0.1.7", new(2017, 5, 26), []),
+        new("0.1.8.1", new DateTime(2017, 5, 27), [
+            new VersionChange("Долги: группировка по имени", ChangeType.Feature),
+            new VersionChange("Долги: удаление", ChangeType.Feature),
+            new VersionChange("Долги: редактирование", ChangeType.Feature),
+        ]),
+
+        new("0.1.7", new DateTime(2017, 5, 26), []),
     ];
 
     private bool _historyVisible;
@@ -311,7 +318,7 @@ public partial class Home
             0 => Color.Default,
             1 => Color.Info,
             2 or 3 => Color.Primary,
-            _ => Color.Secondary,
+            var _ => Color.Secondary,
         };
     }
 
@@ -321,13 +328,13 @@ public partial class Home
         {
             0 => Icons.Material.Rounded.Circle,
             1 => Icons.Material.Rounded.FiberManualRecord,
-            _ => Icons.Material.Rounded.RadioButtonChecked,
+            var _ => Icons.Material.Rounded.RadioButtonChecked,
         };
     }
 
     private Color GetVersionChipColor(VersionHistoryEntry entry)
     {
-        var versionParts = entry.Version.Split('.');
+        string[] versionParts = entry.Version.Split('.');
 
         if (versionParts.Length < 2)
         {
@@ -356,7 +363,7 @@ public partial class Home
             ChangeType.Improvement => Icons.Material.Rounded.TrendingUp,
             ChangeType.UiUx => Icons.Material.Rounded.Palette,
             ChangeType.General => Icons.Material.Rounded.Settings,
-            _ => Icons.Material.Rounded.Circle,
+            var _ => Icons.Material.Rounded.Circle,
         };
     }
 
@@ -369,7 +376,7 @@ public partial class Home
             ChangeType.Improvement => Color.Info,
             ChangeType.UiUx => Color.Warning,
             ChangeType.General => Color.Default,
-            _ => Color.Default,
+            var _ => Color.Default,
         };
     }
 }


### PR DESCRIPTION
Починка чипа подставленной категории
- Исправлен NullReferenceException при отмене подстановки
- Длинное имя обрезается с троеточием, полное видно в подсказке
- Слово «Подставлено» перенесено из чипа в tooltip
- Крестик подсвечивается красным при наведении и показывает подсказку
- Убран вспомогательный текст под полем даты

Доработки поля суммы в диалоге операции 
- Исправлено вычисление суммы с пробелами внутри числа: «1+5 555,00» считается как 5556
- В поле суммы выражение сохраняется после вычисления и доступно для редактирования при возврате фокуса (клик, Tab, иконка-калькулятор)
- Устранена петля фокуса в SmartSum при переключении между numeric и text режимами
- Убрано дублирование спецсимволов при переключении в текстовый режим
- В диалоге операции «Закрыть» убрана из Tab-обхода, «Сохранить» подсвечивается обводкой при клавиатурном фокусе
- Обновлена история изменений: версия 1.3.15